### PR TITLE
Update to yew 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ use yew::html;
 
 html! {
     <MatButton label="Click me!" />
-}
+};
 ```
 
 ## Getting started

--- a/material-yew/Cargo.toml
+++ b/material-yew/Cargo.toml
@@ -14,7 +14,7 @@ description = "Yew wrapper for Material Web Components"
 
 [dependencies]
 wasm-bindgen = "0.2"
-yew = { version = "0.18", default-features = false, features = ["web_sys"] }
+yew = { version = "0.19"}
 js-sys = "0.3"
 paste = "1.0"
 gloo = "0.2"

--- a/material-yew/src/button.rs
+++ b/material-yew/src/button.rs
@@ -1,5 +1,4 @@
 use crate::bool_to_option;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -19,11 +18,11 @@ loader_hack!(Button);
 /// Props for [`MatButton`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/button#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct ButtonProps {
     pub label: String,
     #[prop_or_default]
-    pub icon: Option<Cow<'static, str>>,
+    pub icon: Option<String>,
     #[prop_or_default]
     pub raised: bool,
     #[prop_or_default]
@@ -43,16 +42,16 @@ component!(
     ButtonProps,
     |props: &ButtonProps| {
         html! {
-            <mwc-button
-            icon=props.icon.clone()
-            label=props.label.clone()
-            disabled=props.disabled
-            raised=bool_to_option(props.raised)
-            unelevated=bool_to_option(props.unelevated)
-            outlined=bool_to_option(props.outlined)
-            dense=bool_to_option(props.dense)
-            trailingIcon=bool_to_option(props.trailing_icon)
-            ></mwc-button>
+             <mwc-button
+             icon={props.icon.clone()}
+             label={props.label.clone()}
+             disabled={props.disabled}
+             raised={bool_to_option(props.raised)}
+             unelevated={bool_to_option(props.unelevated)}
+             outlined={bool_to_option(props.outlined)}
+             dense={bool_to_option(props.dense)}
+             trailingIcon={bool_to_option(props.trailing_icon)}
+             ></mwc-button>
         }
     },
     Button,

--- a/material-yew/src/button.rs
+++ b/material-yew/src/button.rs
@@ -1,6 +1,7 @@
 use crate::bool_to_option;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-button.js")]
 extern "C" {
@@ -22,7 +23,7 @@ loader_hack!(Button);
 pub struct ButtonProps {
     pub label: String,
     #[prop_or_default]
-    pub icon: Option<String>,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
     pub raised: bool,
     #[prop_or_default]

--- a/material-yew/src/checkbox.rs
+++ b/material-yew/src/checkbox.rs
@@ -1,6 +1,5 @@
 use crate::bool_to_option;
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::{Element, Node};
 use yew::prelude::*;
@@ -27,7 +26,6 @@ loader_hack!(Checkbox);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/checkbox)
 pub struct MatCheckbox {
-    props: CheckboxProps,
     node_ref: NodeRef,
     change_listener: Option<EventListener>,
 }
@@ -38,7 +36,7 @@ pub struct MatCheckbox {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/checkbox#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/checkbox#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct CheckboxProps {
     #[prop_or_default]
     pub checked: bool,
@@ -47,7 +45,7 @@ pub struct CheckboxProps {
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
-    pub value: Cow<'static, str>,
+    pub value: String,
     #[prop_or_default]
     pub reduced_touch_target: bool,
     /// Binds to `change` event on `mwc-checkbox`
@@ -61,42 +59,34 @@ impl Component for MatCheckbox {
     type Message = ();
     type Properties = CheckboxProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Checkbox::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             change_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-              <mwc-checkbox
-                  indeterminate=bool_to_option(self.props.indeterminate)
-                  disabled=self.props.disabled
-                  value=self.props.value.clone()
-                  reducedTouchTarget=bool_to_option(self.props.reduced_touch_target)
-                  ref=self.node_ref.clone()
-              ></mwc-checkbox>
+               <mwc-checkbox
+                   indeterminate={bool_to_option(props.indeterminate)}
+                   disabled={props.disabled}
+                   value={props.value.clone()}
+                   reducedTouchTarget={bool_to_option(props.reduced_touch_target)}
+                   ref={self.node_ref.clone()}
+               ></mwc-checkbox>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Checkbox>().unwrap();
-        element.set_checked(self.props.checked);
+        element.set_checked(props.checked);
 
         if self.change_listener.is_none() {
-            let callback = self.props.onchange.clone();
+            let callback = props.onchange.clone();
             let target = self.node_ref.cast::<Element>().unwrap();
             self.change_listener = Some(EventListener::new(&target, "change", move |_| {
                 callback.emit(element.checked());

--- a/material-yew/src/checkbox.rs
+++ b/material-yew/src/checkbox.rs
@@ -3,6 +3,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::{Element, Node};
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-checkbox.js")]
 extern "C" {
@@ -45,7 +46,7 @@ pub struct CheckboxProps {
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
-    pub value: String,
+    pub value: Option<AttrValue>,
     #[prop_or_default]
     pub reduced_touch_target: bool,
     /// Binds to `change` event on `mwc-checkbox`

--- a/material-yew/src/circular_progress.rs
+++ b/material-yew/src/circular_progress.rs
@@ -18,7 +18,7 @@ loader_hack!(CircularProgress);
 /// Props for [`MatCircularProgress`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/circular-progress#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct CircularProgressProps {
     #[prop_or_default]
     pub indeterminate: bool,
@@ -35,12 +35,12 @@ component!(
     CircularProgressProps,
     |props: &CircularProgressProps| {
         html! {
-            <mwc-circular-progress
-                indeterminate=bool_to_option(props.indeterminate)
-                progress=to_option_string(props.progress)
-                density=to_option_string(props.density)
-                closed=bool_to_option(props.closed)
-            ></mwc-circular-progress>
+             <mwc-circular-progress
+                 indeterminate={bool_to_option(props.indeterminate)}
+                 progress={to_option_string(props.progress)}
+                 density={to_option_string(props.density)}
+                 closed={bool_to_option(props.closed)}
+             ></mwc-circular-progress>
         }
     },
     CircularProgress,

--- a/material-yew/src/circular_progress_four_color.rs
+++ b/material-yew/src/circular_progress_four_color.rs
@@ -18,7 +18,7 @@ loader_hack!(CircularProgressFourColor);
 /// Props for [`MatCircularProgressFourColor`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/circular-progress-four-color#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct CircularProgressFourColorProps {
     #[prop_or_default]
     pub indeterminate: bool,
@@ -35,12 +35,12 @@ component!(
     CircularProgressFourColorProps,
     |props: &CircularProgressFourColorProps| {
         html! {
-        <mwc-circular-progress-four-color
-            indeterminate=bool_to_option(props.indeterminate)
-            progress=to_option_string(props.progress)
-            density=to_option_string(props.density)
-            closed=bool_to_option(props.closed)
-        ></mwc-circular-progress-four-color>
+         <mwc-circular-progress-four-color
+             indeterminate={bool_to_option(props.indeterminate)}
+             progress={to_option_string(props.progress)}
+             density={to_option_string(props.density)}
+             closed={bool_to_option(props.closed)}
+         ></mwc-circular-progress-four-color>
         }
     },
     CircularProgressFourColor,

--- a/material-yew/src/dialog.rs
+++ b/material-yew/src/dialog.rs
@@ -7,6 +7,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::{Element, Node};
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-dialog.js")]
 extern "C" {
@@ -63,17 +64,17 @@ pub struct DialogProps {
     #[prop_or_default]
     pub stacked: bool,
     #[prop_or_default]
-    pub heading: Option<String>,
+    pub heading: Option<AttrValue>,
     #[prop_or_default]
-    pub scrim_click_action: Option<String>,
+    pub scrim_click_action: Option<AttrValue>,
     #[prop_or_default]
-    pub escape_key_action: Option<String>,
+    pub escape_key_action: Option<AttrValue>,
     #[prop_or_default]
-    pub default_action: Option<String>,
+    pub default_action: Option<AttrValue>,
     #[prop_or_default]
-    pub action_attribute: Option<String>,
+    pub action_attribute: Option<AttrValue>,
     #[prop_or_default]
-    pub initial_focus_attribute: Option<String>,
+    pub initial_focus_attribute: Option<AttrValue>,
     /// Binds to `opening` event on `mwc-dialog`
     ///
     /// See events docs to learn more.

--- a/material-yew/src/dialog/dialog_action.rs
+++ b/material-yew/src/dialog/dialog_action.rs
@@ -40,14 +40,14 @@ pub struct ActionProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDialogAction;
+pub struct MatDialogAction {}
 
 impl Component for MatDialogAction {
     type Message = ();
     type Properties = ActionProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/dialog/dialog_action.rs
+++ b/material-yew/src/dialog/dialog_action.rs
@@ -1,9 +1,8 @@
-use std::borrow::Cow;
 use std::fmt;
 use yew::prelude::*;
 
 /// Dialog action type.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum ActionType {
     /// Binds `to slot` of `primaryAction`
     Primary,
@@ -12,27 +11,26 @@ pub enum ActionType {
 }
 
 impl ActionType {
-    fn to_cow_string(&self) -> Cow<'static, str> {
-        let s = match self {
+    fn as_str(&self) -> &'static str {
+        match self {
             ActionType::Primary => "primaryAction",
             ActionType::Secondary => "secondaryAction",
-        };
-        Cow::from(s)
+        }
     }
 }
 
 impl fmt::Display for ActionType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_cow_string())
+        write!(f, "{}", self.as_str())
     }
 }
 
 /// Props for [`MatDialogAction`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct ActionProps {
     pub action_type: ActionType,
     #[prop_or_default]
-    pub action: Option<Cow<'static, str>>,
+    pub action: Option<String>,
     pub children: Children,
 }
 
@@ -41,47 +39,37 @@ pub struct ActionProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDialogAction {
-    props: ActionProps,
-}
+pub struct MatDialogAction;
 
 impl Component for MatDialogAction {
     type Message = ();
     type Properties = ActionProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self.props.children.iter().map(|child| {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props.children.iter().map(|child| {
             match child {
                 Html::VTag(mut vtag) => {
-                    vtag.add_attribute("slot", self.props.action_type.to_string());
-                    if let Some(action) = self.props.action.as_ref() {
+                    vtag.add_attribute("slot", props.action_type.to_string());
+                    if let Some(action) = props.action.as_ref() {
                         vtag.add_attribute("dialogAction", action.to_owned());
-                    }
+                   }
                     Html::VTag(vtag)
-                }
+               }
                 _ => html! {
-                    <span slot=self.props.action_type.to_string() dialogAction=self.props.action.clone()>
-                        { child }
+                    <span slot={props.action_type.to_string()} dialogAction={props.action.clone()}>
+                        {child}
                     </span>
-                }
-            }
-        }).collect::<Html>();
+               }
+           }
+       }).collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/dialog/dialog_action.rs
+++ b/material-yew/src/dialog/dialog_action.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 /// Dialog action type.
 #[derive(Clone, PartialEq)]
@@ -30,7 +31,7 @@ impl fmt::Display for ActionType {
 pub struct ActionProps {
     pub action_type: ActionType,
     #[prop_or_default]
-    pub action: Option<String>,
+    pub action: Option<AttrValue>,
     pub children: Children,
 }
 

--- a/material-yew/src/drawer.rs
+++ b/material-yew/src/drawer.rs
@@ -13,6 +13,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-drawer.js")]
 extern "C" {
@@ -57,7 +58,7 @@ pub struct DrawerProps {
     #[prop_or_default]
     pub has_header: bool,
     #[prop_or_default]
-    pub drawer_type: String,
+    pub drawer_type: Option<AttrValue>,
     /// Binds to `opened` event on `mwc-drawer`
     ///
     /// See events docs to learn more.
@@ -102,7 +103,13 @@ impl Component for MatDrawer {
     fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
         let props = ctx.props();
         let element = self.node_ref.cast::<Drawer>().unwrap();
-        element.set_type(&JsValue::from_str(props.drawer_type.as_ref()));
+        element.set_type(&JsValue::from(
+            props
+                .drawer_type
+                .as_ref()
+                .map(|s| s.as_ref())
+                .unwrap_or_default(),
+        ));
         element.set_open(props.open);
 
         if self.opened_listener.is_none() {

--- a/material-yew/src/drawer.rs
+++ b/material-yew/src/drawer.rs
@@ -10,7 +10,6 @@ pub use drawer_title::*;
 
 use crate::{bool_to_option, WeakComponentLink};
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
@@ -40,7 +39,6 @@ loader_hack!(Drawer);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/drawer)
 pub struct MatDrawer {
-    props: DrawerProps,
     node_ref: NodeRef,
     opened_listener: Option<EventListener>,
     closed_listener: Option<EventListener>,
@@ -52,14 +50,14 @@ pub struct MatDrawer {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/drawer#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/drawer#events)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct DrawerProps {
     #[prop_or_default]
     pub open: bool,
     #[prop_or_default]
     pub has_header: bool,
     #[prop_or_default]
-    pub drawer_type: Cow<'static, str>,
+    pub drawer_type: String,
     /// Binds to `opened` event on `mwc-drawer`
     ///
     /// See events docs to learn more.
@@ -79,41 +77,36 @@ impl Component for MatDrawer {
     type Message = ();
     type Properties = DrawerProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        props.drawer_link.borrow_mut().replace(link);
+    fn create(ctx: &Context<Self>) -> Self {
+        ctx.props()
+            .drawer_link
+            .borrow_mut()
+            .replace(ctx.link().clone());
         Drawer::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             opened_listener: None,
             closed_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-        <mwc-drawer hasHeader=bool_to_option(self.props.has_header) ref=self.node_ref.clone()>
-            { self.props.children.clone() }
+        <mwc-drawer hasHeader={bool_to_option(props.has_header)} ref={self.node_ref.clone()}>
+            {props.children.clone()}
         </mwc-drawer>
-                }
+               }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Drawer>().unwrap();
-        element.set_type(&JsValue::from(self.props.drawer_type.as_ref()));
-        element.set_open(self.props.open);
+        element.set_type(&JsValue::from_str(props.drawer_type.as_ref()));
+        element.set_open(props.open);
 
         if self.opened_listener.is_none() {
-            let onopen_callback = self.props.onopened.clone();
+            let onopen_callback = props.onopened.clone();
             self.opened_listener = Some(EventListener::new(
                 &element,
                 "MDCDrawer:opened",
@@ -124,7 +117,7 @@ impl Component for MatDrawer {
         }
 
         if self.closed_listener.is_none() {
-            let onclose_callback = self.props.onclosed.clone();
+            let onclose_callback = props.onclosed.clone();
             self.closed_listener = Some(EventListener::new(
                 &element,
                 "MDCDrawer:closed",

--- a/material-yew/src/drawer/drawer_app_content.rs
+++ b/material-yew/src/drawer/drawer_app_content.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "appContent";
 
 /// Props for [`MatDrawerAppContent`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct DrawerAppContentProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct DrawerAppContentProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerAppContent {
-    props: DrawerAppContentProps,
-}
+pub struct MatDrawerAppContent;
 
 impl Component for MatDrawerAppContent {
     type Message = ();
     type Properties = DrawerAppContentProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatDrawerAppContent {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatDrawerAppContent {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/drawer/drawer_app_content.rs
+++ b/material-yew/src/drawer/drawer_app_content.rs
@@ -13,14 +13,14 @@ pub struct DrawerAppContentProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerAppContent;
+pub struct MatDrawerAppContent {}
 
 impl Component for MatDrawerAppContent {
     type Message = ();
     type Properties = DrawerAppContentProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/drawer/drawer_header.rs
+++ b/material-yew/src/drawer/drawer_header.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "header";
 
 /// Props for [`MatDrawerHeader`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct DrawerHeaderProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct DrawerHeaderProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerHeader {
-    props: DrawerHeaderProps,
-}
+pub struct MatDrawerHeader;
 
 impl Component for MatDrawerHeader {
     type Message = ();
     type Properties = DrawerHeaderProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatDrawerHeader {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatDrawerHeader {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/drawer/drawer_header.rs
+++ b/material-yew/src/drawer/drawer_header.rs
@@ -13,14 +13,14 @@ pub struct DrawerHeaderProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerHeader;
+pub struct MatDrawerHeader {}
 
 impl Component for MatDrawerHeader {
     type Message = ();
     type Properties = DrawerHeaderProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/drawer/drawer_subtitle.rs
+++ b/material-yew/src/drawer/drawer_subtitle.rs
@@ -13,14 +13,14 @@ pub struct DrawerSubtitleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerSubtitle;
+pub struct MatDrawerSubtitle {}
 
 impl Component for MatDrawerSubtitle {
     type Message = ();
     type Properties = DrawerSubtitleProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/drawer/drawer_subtitle.rs
+++ b/material-yew/src/drawer/drawer_subtitle.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "subtitle";
 
 /// Props for [`MatDrawerSubtitle`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct DrawerSubtitleProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct DrawerSubtitleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerSubtitle {
-    props: DrawerSubtitleProps,
-}
+pub struct MatDrawerSubtitle;
 
 impl Component for MatDrawerSubtitle {
     type Message = ();
     type Properties = DrawerSubtitleProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatDrawerSubtitle {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatDrawerSubtitle {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/drawer/drawer_title.rs
+++ b/material-yew/src/drawer/drawer_title.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "title";
 
 /// Props for [`MatDrawerTitle`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct DrawerTitleProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct DrawerTitleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerTitle {
-    props: DrawerTitleProps,
-}
+pub struct MatDrawerTitle;
 
 impl Component for MatDrawerTitle {
     type Message = ();
     type Properties = DrawerTitleProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatDrawerTitle {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatDrawerTitle {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/drawer/drawer_title.rs
+++ b/material-yew/src/drawer/drawer_title.rs
@@ -13,14 +13,14 @@ pub struct DrawerTitleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatDrawerTitle;
+pub struct MatDrawerTitle {}
 
 impl Component for MatDrawerTitle {
     type Message = ();
     type Properties = DrawerTitleProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/fab.rs
+++ b/material-yew/src/fab.rs
@@ -1,6 +1,7 @@
 use crate::bool_to_option;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-fab.js")]
 extern "C" {
@@ -19,9 +20,9 @@ loader_hack!(Fab);
 #[derive(Debug, Properties, PartialEq, Clone)]
 pub struct FabProps {
     #[prop_or_default]
-    pub icon: String,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
     pub mini: bool,
     #[prop_or_default]

--- a/material-yew/src/fab.rs
+++ b/material-yew/src/fab.rs
@@ -1,5 +1,4 @@
 use crate::bool_to_option;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -17,12 +16,12 @@ loader_hack!(Fab);
 /// Props for [`MatFab`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/fab#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct FabProps {
     #[prop_or_default]
-    pub icon: Cow<'static, str>,
+    pub icon: String,
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
     pub mini: bool,
     #[prop_or_default]
@@ -40,14 +39,14 @@ component!(
     FabProps,
     |props: &FabProps| {
         html! {
-            <mwc-fab
-                label=props.label.clone()
-                icon=props.icon.clone()
-                mini=bool_to_option(props.mini)
-                reducedTouchTarget=bool_to_option(props.reduced_touch_target)
-                extended=bool_to_option(props.extended)
-                showIconAtEnd=bool_to_option(props.show_icon_at_end)
-            >{ props.children.clone() }</mwc-fab>
+             <mwc-fab
+                 label={props.label.clone()}
+                 icon={props.icon.clone()}
+                 mini={bool_to_option(props.mini)}
+                 reducedTouchTarget={bool_to_option(props.reduced_touch_target)}
+                 extended={bool_to_option(props.extended)}
+                 showIconAtEnd={bool_to_option(props.show_icon_at_end)}
+             >{props.children.clone()}</mwc-fab>
         }
     },
     Fab,

--- a/material-yew/src/form_field.rs
+++ b/material-yew/src/form_field.rs
@@ -1,6 +1,7 @@
 use crate::bool_to_option;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-formfield.js")]
 extern "C" {
@@ -20,7 +21,7 @@ loader_hack!(Formfield);
 pub struct FormfieldProps {
     pub children: Children,
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
     pub align_end: bool,
     #[prop_or_default]

--- a/material-yew/src/form_field.rs
+++ b/material-yew/src/form_field.rs
@@ -1,5 +1,4 @@
 use crate::bool_to_option;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -17,11 +16,11 @@ loader_hack!(Formfield);
 /// Props for [`MatFormfield`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/formfield#propertiesattributes)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct FormfieldProps {
     pub children: Children,
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
     pub align_end: bool,
     #[prop_or_default]
@@ -35,12 +34,12 @@ component!(
     FormfieldProps,
     |props: &FormfieldProps| {
         html! {
-            <mwc-formfield
-                label=props.label.clone()
-                alignEnd=bool_to_option(props.align_end)
-                spaceBetween=bool_to_option(props.space_between)
-                nowrap=bool_to_option(props.nowrap)
-            >{ props.children.clone() }</mwc-formfield>
+             <mwc-formfield
+                 label={props.label.clone()}
+                 alignEnd={bool_to_option(props.align_end)}
+                 spaceBetween={bool_to_option(props.space_between)}
+                 nowrap={bool_to_option(props.nowrap)}
+             >{props.children.clone()}</mwc-formfield>
         }
     },
     Formfield,

--- a/material-yew/src/icon.rs
+++ b/material-yew/src/icon.rs
@@ -15,7 +15,7 @@ loader_hack!(Icon);
 /// Props for [`MatIcon`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/icon#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct IconProps {
     pub children: Children,
 }
@@ -25,7 +25,7 @@ component!(
     IconProps,
     |props: &IconProps| {
         html! {
-            <mwc-icon>{ props.children.clone() }</mwc-icon>
+             <mwc-icon>{props.children.clone()}</mwc-icon>
         }
     },
     Icon,

--- a/material-yew/src/icon_button.rs
+++ b/material-yew/src/icon_button.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-icon-button.js")]
 extern "C" {
@@ -18,9 +19,9 @@ loader_hack!(IconButton);
 #[derive(Debug, Properties, PartialEq, Clone)]
 pub struct IconButtonProps {
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
-    pub icon: String,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]

--- a/material-yew/src/icon_button.rs
+++ b/material-yew/src/icon_button.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -16,12 +15,12 @@ loader_hack!(IconButton);
 /// Props for [`MatIconButton`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/icon-button#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct IconButtonProps {
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
-    pub icon: Cow<'static, str>,
+    pub icon: String,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
@@ -33,11 +32,11 @@ component!(
     IconButtonProps,
     |props: &IconButtonProps| {
         html! {
-            <mwc-icon-button
-                label=props.label.clone()
-                icon=props.icon.clone()
-                disabled=props.disabled
-            >{ props.children.clone() }</mwc-icon-button>
+             <mwc-icon-button
+                 label={props.label.clone()}
+                 icon={props.icon.clone()}
+                 disabled={props.disabled}
+             >{props.children.clone()}</mwc-icon-button>
         }
     },
     IconButton,

--- a/material-yew/src/icon_button_toggle.rs
+++ b/material-yew/src/icon_button_toggle.rs
@@ -9,6 +9,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-icon-button-toggle.js")]
 extern "C" {
@@ -44,11 +45,11 @@ pub struct IconButtonToggleProps {
     #[prop_or_default]
     pub on: bool,
     #[prop_or_default]
-    pub on_icon: String,
+    pub on_icon: Option<AttrValue>,
     #[prop_or_default]
-    pub off_icon: String,
+    pub off_icon: Option<AttrValue>,
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
     pub disabled: bool,
     /// Binds to `MDCIconButtonToggle:change`.

--- a/material-yew/src/icon_button_toggle.rs
+++ b/material-yew/src/icon_button_toggle.rs
@@ -6,7 +6,6 @@ pub use on_icon::*;
 
 use crate::bool_to_option;
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
@@ -30,7 +29,6 @@ loader_hack!(IconButtonToggle);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/icon-button-toggle)
 pub struct MatIconButtonToggle {
-    props: IconButtonToggleProps,
     node_ref: NodeRef,
     change_listener: Option<EventListener>,
 }
@@ -41,16 +39,16 @@ pub struct MatIconButtonToggle {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/icon-button-toggle#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/icon-button-toggle#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct IconButtonToggleProps {
     #[prop_or_default]
     pub on: bool,
     #[prop_or_default]
-    pub on_icon: Cow<'static, str>,
+    pub on_icon: String,
     #[prop_or_default]
-    pub off_icon: Cow<'static, str>,
+    pub off_icon: String,
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
     pub disabled: bool,
     /// Binds to `MDCIconButtonToggle:change`.
@@ -68,42 +66,34 @@ impl Component for MatIconButtonToggle {
     type Message = ();
     type Properties = IconButtonToggleProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         IconButtonToggle::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             change_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-icon-button-toggle
-                on=bool_to_option(self.props.on)
-                onIcon=self.props.on_icon.clone()
-                offIcon=self.props.off_icon.clone()
-                label=self.props.label.clone()
-                disabled=self.props.disabled
-                ref=self.node_ref.clone()
-            > { self.props.children.clone() }</mwc-icon-button-toggle>
+             <mwc-icon-button-toggle
+                 on={bool_to_option(props.on)}
+                 onIcon={props.on_icon.clone()}
+                 offIcon={props.off_icon.clone()}
+                 label={props.label.clone()}
+                 disabled={props.disabled}
+                 ref={self.node_ref.clone()}
+             > {props.children.clone()}</mwc-icon-button-toggle>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.change_listener.is_none() {
             let element = self.node_ref.cast::<IconButtonToggle>().unwrap();
 
-            let callback = self.props.onchange.clone();
+            let callback = props.onchange.clone();
             self.change_listener = Some(EventListener::new(
                 &element.clone(),
                 "MDCIconButtonToggle:change",

--- a/material-yew/src/icon_button_toggle/off_icon.rs
+++ b/material-yew/src/icon_button_toggle/off_icon.rs
@@ -13,14 +13,14 @@ pub struct OffIconButtonToggleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatOffIconButtonToggle;
+pub struct MatOffIconButtonToggle {}
 
 impl Component for MatOffIconButtonToggle {
     type Message = ();
     type Properties = OffIconButtonToggleProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/icon_button_toggle/off_icon.rs
+++ b/material-yew/src/icon_button_toggle/off_icon.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "offIcon";
 
 /// Props for [`MatOffIconButtonToggle`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct OffIconButtonToggleProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct OffIconButtonToggleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatOffIconButtonToggle {
-    props: OffIconButtonToggleProps,
-}
+pub struct MatOffIconButtonToggle;
 
 impl Component for MatOffIconButtonToggle {
     type Message = ();
     type Properties = OffIconButtonToggleProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatOffIconButtonToggle {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatOffIconButtonToggle {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/icon_button_toggle/on_icon.rs
+++ b/material-yew/src/icon_button_toggle/on_icon.rs
@@ -13,14 +13,14 @@ pub struct OnIconButtonToggleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatOnIconButtonToggle;
+pub struct MatOnIconButtonToggle {}
 
 impl Component for MatOnIconButtonToggle {
     type Message = ();
     type Properties = OnIconButtonToggleProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/icon_button_toggle/on_icon.rs
+++ b/material-yew/src/icon_button_toggle/on_icon.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "onIcon";
 
 /// Props for [`MatOnIconButtonToggle`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct OnIconButtonToggleProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct OnIconButtonToggleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatOnIconButtonToggle {
-    props: OnIconButtonToggleProps,
-}
+pub struct MatOnIconButtonToggle;
 
 impl Component for MatOnIconButtonToggle {
     type Message = ();
     type Properties = OnIconButtonToggleProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatOnIconButtonToggle {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatOnIconButtonToggle {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/lib.rs
+++ b/material-yew/src/lib.rs
@@ -66,16 +66,16 @@ macro_rules! component {
    };
 }
 
-fn bool_to_option(value: bool) -> Option<String> {
-    value.then(|| String::from("true"))
+fn bool_to_option(value: bool) -> Option<AttrValue> {
+    value.then(|| AttrValue::Static("true"))
 }
 
-fn to_option_string(s: impl Display) -> Option<String> {
+fn to_option_string(s: impl Display) -> Option<AttrValue> {
     let s = s.to_string();
     if s.is_empty() {
         None
     } else {
-        Some(s)
+        Some(AttrValue::Owned(s))
     }
 }
 
@@ -237,6 +237,7 @@ pub use menu::MatMenu;
 use std::fmt::Display;
 #[doc(hidden)]
 pub use utils::WeakComponentLink;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/core.js")]
 extern "C" {

--- a/material-yew/src/lib.rs
+++ b/material-yew/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc(html_root_url = "/docs")]
-
+// See: https://github.com/rustwasm/wasm-bindgen/issues/2774
+// Can remove when wasm-bindgen is updated.
+#![allow(clippy::unused_unit)]
 //! A Material components library for [Yew](https://yew.rs). It wrpas around [Material Web Components](https://github.com/material-components/material-components-web-components) exposing Yew components.
 //!
 //! Example usage:
@@ -9,7 +11,7 @@
 //!
 //! html! {
 //!     <MatButton label="Click me!" />
-//! }
+//! };
 //! ```
 //!
 //! All the main components from the modules are re-exported.

--- a/material-yew/src/lib.rs
+++ b/material-yew/src/lib.rs
@@ -45,44 +45,35 @@ macro_rules! component {
             #[doc = "The `mwc-" $mwc_name "` component"]
             #[doc = ""]
             #[doc = "[MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/"$mwc_name")"]
-            pub struct $comp {
-                props: $props
-            }
-        }
+            pub struct $comp;
+       }
         impl yew::Component for $comp {
             type Message = ();
             type Properties = $props;
 
-            fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+            fn create(_: &Context<Self>) -> Self {
                 $mwc_to_initialize::ensure_loaded();
-                Self { props }
-            }
+                Self
+           }
 
-            fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-                false
-            }
-
-            fn change(&mut self, props: Self::Properties) -> bool {
-                self.props = props;
-                true
-            }
-
-            fn view(&self) -> Html {
-                $html(&self.props)
-            }
-        }
-    };
+            fn view(&self, ctx: &Context<Self>) -> Html {
+                let props = ctx.props();
+                $html(props)
+           }
+       }
+   };
 }
 
-fn bool_to_option(value: bool) -> Option<Cow<'static, str>> {
-    value.then(|| Cow::from("true"))
+fn bool_to_option(value: bool) -> Option<String> {
+    value.then(|| String::from("true"))
 }
 
-fn to_option_string(s: impl Display) -> Option<Cow<'static, str>> {
+fn to_option_string(s: impl Display) -> Option<String> {
     let s = s.to_string();
-    match s.as_str() {
-        "" => None,
-        _ => Some(Cow::from(s)),
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
     }
 }
 
@@ -241,7 +232,6 @@ pub mod menu;
 #[doc(hidden)]
 pub use menu::MatMenu;
 
-use std::borrow::Cow;
 use std::fmt::Display;
 #[doc(hidden)]
 pub use utils::WeakComponentLink;

--- a/material-yew/src/linear_progress.rs
+++ b/material-yew/src/linear_progress.rs
@@ -16,7 +16,7 @@ loader_hack!(LinearProgress);
 /// Props for [`MatLinearProgress`]
 ///
 /// [MWC Documentation for properties](https://github.com/material-components/material-components-web-components/tree/master/packages/linear-progress#propertiesattributes)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct LinearProgressProps {
     #[prop_or_default]
     pub indeterminate: bool,
@@ -35,13 +35,13 @@ component!(
     LinearProgressProps,
     |props: &LinearProgressProps| {
         html! {
-            <mwc-linear-progress
-                indeterminate=bool_to_option(props.indeterminate)
-                progress=to_option_string(props.progress)
-                buffer=to_option_string(props.buffer)
-                reverse=bool_to_option(props.reverse)
-                closed=bool_to_option(props.closed)
-            ></mwc-linear-progress>
+             <mwc-linear-progress
+                 indeterminate={bool_to_option(props.indeterminate)}
+                 progress={to_option_string(props.progress)}
+                 buffer={to_option_string(props.buffer)}
+                 reverse={bool_to_option(props.reverse)}
+                 closed={bool_to_option(props.closed)}
+             ></mwc-linear-progress>
         }
     },
     LinearProgress,

--- a/material-yew/src/list.rs
+++ b/material-yew/src/list.rs
@@ -27,6 +27,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-list.js")]
 extern "C" {
@@ -78,9 +79,9 @@ pub struct ListProps {
     #[prop_or_default]
     pub wrap_focus: bool,
     #[prop_or_default]
-    pub item_roles: Option<String>,
+    pub item_roles: Option<AttrValue>,
     #[prop_or_default]
-    pub inner_role: Option<String>,
+    pub inner_role: Option<AttrValue>,
     #[prop_or_default]
     pub noninteractive: bool,
     /// Binds to `action` event on `mwc-list`

--- a/material-yew/src/list.rs
+++ b/material-yew/src/list.rs
@@ -24,7 +24,6 @@ pub use graphic_type::GraphicType;
 
 use crate::{bool_to_option, event_into_details, WeakComponentLink};
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
@@ -57,7 +56,6 @@ loader_hack!(List);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/list)
 pub struct MatList {
-    props: ListProps,
     node_ref: NodeRef,
     action_listener: Option<EventListener>,
     selected_listener: Option<EventListener>,
@@ -69,7 +67,7 @@ pub struct MatList {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-1)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-2)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct ListProps {
     #[prop_or_default]
     pub activatable: bool,
@@ -80,9 +78,9 @@ pub struct ListProps {
     #[prop_or_default]
     pub wrap_focus: bool,
     #[prop_or_default]
-    pub item_roles: Option<Cow<'static, str>>,
+    pub item_roles: Option<String>,
     #[prop_or_default]
-    pub inner_role: Option<Cow<'static, str>>,
+    pub inner_role: Option<String>,
     #[prop_or_default]
     pub noninteractive: bool,
     /// Binds to `action` event on `mwc-list`
@@ -106,47 +104,42 @@ impl Component for MatList {
     type Message = ();
     type Properties = ListProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        props.list_link.borrow_mut().replace(link);
+    fn create(ctx: &Context<Self>) -> Self {
+        ctx.props()
+            .list_link
+            .borrow_mut()
+            .replace(ctx.link().clone());
         List::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             action_listener: None,
             selected_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-list
-                activatable=bool_to_option(self.props.activatable)
-                rootTabbable=bool_to_option(self.props.root_tabbable)
-                multi=bool_to_option(self.props.multi)
-                wrapFocus=bool_to_option(self.props.wrap_focus)
-                itemRoles=self.props.item_roles.clone()
-                innerRole=self.props.inner_role.clone()
-                noninteractive=bool_to_option(self.props.noninteractive)
-                ref=self.node_ref.clone()
-            >
-              { self.props.children.clone() }
-            </mwc-list>
+             <mwc-list
+                 activatable={bool_to_option(props.activatable) }
+                 rootTabbable={bool_to_option(props.root_tabbable)}
+                 multi={bool_to_option(props.multi)}
+                 wrapFocus={bool_to_option(props.wrap_focus)}
+                 itemRoles={props.item_roles.clone()}
+                 innerRole={props.inner_role.clone()}
+                 noninteractive={bool_to_option(props.noninteractive)}
+                 ref={self.node_ref.clone()}
+             >
+               {props.children.clone()}
+             </mwc-list>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let list = self.node_ref.cast::<List>().unwrap();
         if self.selected_listener.is_none() {
-            let onselected = self.props.onselected.clone();
+            let onselected = props.onselected.clone();
             self.selected_listener = Some(EventListener::new(&list, "selected", move |event| {
                 let val = SelectedDetail::from(event_into_details(event));
                 onselected.emit(val);
@@ -154,7 +147,7 @@ impl Component for MatList {
         }
 
         if self.action_listener.is_none() {
-            let onaction = self.props.onaction.clone();
+            let onaction = props.onaction.clone();
             self.action_listener = Some(EventListener::new(&list.clone(), "action", move |_| {
                 let val: JsValue = list.index();
                 let index = ListIndex::from(val);

--- a/material-yew/src/list/action_detail.rs
+++ b/material-yew/src/list/action_detail.rs
@@ -8,6 +8,7 @@ use wasm_bindgen::JsCast;
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-2)
 #[derive(Debug)]
 pub struct ActionDetail {
+    #[allow(dead_code)]
     index: ListIndex,
 }
 

--- a/material-yew/src/list/check_list_item.rs
+++ b/material-yew/src/list/check_list_item.rs
@@ -20,7 +20,6 @@ loader_hack!(CheckListItem);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/list#checklist)
 pub struct MatCheckListItem {
-    props: CheckListItemProps,
     node_ref: NodeRef,
     request_selected_listener: Option<EventListener>,
 }
@@ -29,7 +28,7 @@ pub struct MatCheckListItem {
 ///
 /// MWC Documentation for [properties](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-check-list-item)
 /// and [events](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-check-list-item-1)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct CheckListItemProps {
     #[prop_or_default]
     pub left: bool,
@@ -46,40 +45,32 @@ impl Component for MatCheckListItem {
     type Message = ();
     type Properties = CheckListItemProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         CheckListItem::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             request_selected_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-check-list-item
-                left=bool_to_option(self.props.left)
-                graphic=self.props.graphic.to_cow_string()
-                disabled=self.props.disabled
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-check-list-item>
+             <mwc-check-list-item
+                 left={bool_to_option(props.left)}
+                 graphic={props.graphic.as_str()}
+                 disabled={props.disabled}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-check-list-item>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.request_selected_listener.is_none() {
             self.request_selected_listener = Some(request_selected_listener(
                 &self.node_ref,
-                self.props.on_request_selected.clone(),
+                props.on_request_selected.clone(),
             ));
         }
     }

--- a/material-yew/src/list/graphic_type.rs
+++ b/material-yew/src/list/graphic_type.rs
@@ -1,11 +1,10 @@
-use std::borrow::Cow;
 use std::fmt;
 
 /// Equivalent to typescript type
 /// `'avatar'|'icon'|'medium'|'large'|'control'|null`
 ///
 /// See `GraphicType` [here](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-item-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum GraphicType {
     Avatar,
     Icon,
@@ -16,22 +15,21 @@ pub enum GraphicType {
 }
 
 impl GraphicType {
-    pub fn to_cow_string(&self) -> Cow<'static, str> {
+    pub fn as_str(&self) -> &'static str {
         use GraphicType::*;
-        let s = match self {
+        match self {
             Avatar => "avatar",
             Icon => "icon",
             Medium => "medium",
             Large => "large",
             Control => "control",
             Null => "null",
-        };
-        Cow::from(s)
+        }
     }
 }
 
 impl fmt::Display for GraphicType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_cow_string())
+        write!(f, "{}", self.as_str())
     }
 }

--- a/material-yew/src/list/list_item.rs
+++ b/material-yew/src/list/list_item.rs
@@ -2,7 +2,6 @@ use crate::list::request_selected::request_selected_listener;
 use crate::list::{GraphicType, RequestSelectedDetail};
 use crate::{bool_to_option, to_option_string};
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -21,7 +20,6 @@ loader_hack!(ListItem);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-item)
 pub struct MatListItem {
-    props: ListItemProps,
     node_ref: NodeRef,
     request_selected_listener: Option<EventListener>,
 }
@@ -30,10 +28,10 @@ pub struct MatListItem {
 ///
 /// MWC Documentation [properties](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-item-1)
 /// and [events](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-list-item-2)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct ListItemProps {
     #[prop_or_default]
-    pub value: Cow<'static, str>,
+    pub value: String,
     #[prop_or_default]
     pub group: bool,
     #[prop_or(- 1)]
@@ -64,48 +62,40 @@ impl Component for MatListItem {
     type Message = ();
     type Properties = ListItemProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         ListItem::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             request_selected_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-list-item
-                value=self.props.value.clone()
-                group=bool_to_option(self.props.group)
-                tabindex=to_option_string(self.props.tabindex)
-                disabled=self.props.disabled
-                twoline=bool_to_option(self.props.twoline)
-                activated=bool_to_option(self.props.activated)
-                graphic=to_option_string(self.props.graphic.to_string())
-                multipleGraphics=bool_to_option(self.props.multiple_graphics)
-                hasMeta=bool_to_option(self.props.has_meta)
-                noninteractive=bool_to_option(self.props.noninteractive)
-                selected=self.props.selected
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-list-item>
+             <mwc-list-item
+                 value={props.value.clone()}
+                 group={bool_to_option(props.group)}
+                 tabindex={to_option_string(props.tabindex)}
+                 disabled={props.disabled}
+                 twoline={bool_to_option(props.twoline)}
+                 activated={bool_to_option(props.activated)}
+                 graphic={to_option_string(props.graphic.to_string())}
+                 multipleGraphics={bool_to_option(props.multiple_graphics)}
+                 hasMeta={bool_to_option(props.has_meta)}
+                 noninteractive={bool_to_option(props.noninteractive)}
+                 selected={props.selected}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-list-item>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.request_selected_listener.is_none() {
             self.request_selected_listener = Some(request_selected_listener(
                 &self.node_ref,
-                self.props.on_request_selected.clone(),
+                props.on_request_selected.clone(),
             ));
         }
     }

--- a/material-yew/src/list/list_item.rs
+++ b/material-yew/src/list/list_item.rs
@@ -4,6 +4,7 @@ use crate::{bool_to_option, to_option_string};
 use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-list-item.js")]
 extern "C" {
@@ -31,7 +32,7 @@ pub struct MatListItem {
 #[derive(Debug, Properties, PartialEq, Clone)]
 pub struct ListItemProps {
     #[prop_or_default]
-    pub value: String,
+    pub value: Option<AttrValue>,
     #[prop_or_default]
     pub group: bool,
     #[prop_or(- 1)]

--- a/material-yew/src/list/radio_list_item.rs
+++ b/material-yew/src/list/radio_list_item.rs
@@ -60,7 +60,7 @@ impl Component for MatRadioListItem {
              <mwc-radio-list-item
                  left={bool_to_option(props.left)}
                  graphic={props.graphic.to_string()}
-                 group={props.group.clone().unwrap_or(String::from("null"))}
+                 group={props.group.clone().unwrap_or_else(|| String::from("null"))}
                  ref={self.node_ref.clone()}
              >{props.children.clone()}</mwc-radio-list-item>
         }

--- a/material-yew/src/list/radio_list_item.rs
+++ b/material-yew/src/list/radio_list_item.rs
@@ -4,6 +4,7 @@ use crate::list::{GraphicType, RequestSelectedDetail};
 use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-radio-list-item.js")]
 extern "C" {
@@ -33,7 +34,7 @@ pub struct RadioListItemProps {
     #[prop_or_default]
     pub left: bool,
     #[prop_or_default]
-    pub group: Option<String>,
+    pub group: Option<AttrValue>,
     #[prop_or(GraphicType::Control)]
     pub graphic: GraphicType,
     /// Binds to `request-selected` event on `mwc-list-item`.
@@ -60,7 +61,7 @@ impl Component for MatRadioListItem {
              <mwc-radio-list-item
                  left={bool_to_option(props.left)}
                  graphic={props.graphic.to_string()}
-                 group={props.group.clone().unwrap_or_else(|| String::from("null"))}
+                 group={props.group.clone().unwrap_or_else(|| AttrValue::from("null"))}
                  ref={self.node_ref.clone()}
              >{props.children.clone()}</mwc-radio-list-item>
         }

--- a/material-yew/src/list/radio_list_item.rs
+++ b/material-yew/src/list/radio_list_item.rs
@@ -2,7 +2,6 @@ use crate::bool_to_option;
 use crate::list::request_selected::request_selected_listener;
 use crate::list::{GraphicType, RequestSelectedDetail};
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use yew::prelude::*;
 
@@ -21,7 +20,6 @@ loader_hack!(RadioListItem);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-radio-list-item)
 pub struct MatRadioListItem {
-    props: RadioListItemProps,
     node_ref: NodeRef,
     request_selected_listener: Option<EventListener>,
 }
@@ -30,12 +28,12 @@ pub struct MatRadioListItem {
 ///
 /// MWC Documentation [properties](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-radio-list-item-1)
 /// and [events](https://github.com/material-components/material-components-web-components/tree/master/packages/list#mwc-radio-list-item-2)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct RadioListItemProps {
     #[prop_or_default]
     pub left: bool,
     #[prop_or_default]
-    pub group: Option<Cow<'static, str>>,
+    pub group: Option<String>,
     #[prop_or(GraphicType::Control)]
     pub graphic: GraphicType,
     /// Binds to `request-selected` event on `mwc-list-item`.
@@ -48,40 +46,32 @@ impl Component for MatRadioListItem {
     type Message = ();
     type Properties = RadioListItemProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         RadioListItem::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             request_selected_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-radio-list-item
-                left=bool_to_option(self.props.left)
-                graphic=self.props.graphic.to_string()
-                group=self.props.group.as_ref().unwrap_or(&Cow::from("null"))
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-radio-list-item>
+             <mwc-radio-list-item
+                 left={bool_to_option(props.left)}
+                 graphic={props.graphic.to_string()}
+                 group={props.group.clone().unwrap_or(String::from("null"))}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-radio-list-item>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.request_selected_listener.is_none() {
             self.request_selected_listener = Some(request_selected_listener(
                 &self.node_ref,
-                self.props.on_request_selected.clone(),
+                props.on_request_selected.clone(),
             ));
         }
     }

--- a/material-yew/src/menu.rs
+++ b/material-yew/src/menu.rs
@@ -8,6 +8,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-menu.js")]
 extern "C" {
@@ -90,7 +91,7 @@ pub struct MenuProps {
     #[prop_or_default]
     pub wrap_focus: bool,
     #[prop_or_default]
-    pub inner_role: String,
+    pub inner_role: Option<AttrValue>,
     #[prop_or_default]
     pub multi: bool,
     #[prop_or_default]

--- a/material-yew/src/menu.rs
+++ b/material-yew/src/menu.rs
@@ -5,7 +5,6 @@ pub use models::*;
 use crate::list::{ListIndex, SelectedDetail};
 use crate::{bool_to_option, event_into_details, to_option_string, WeakComponentLink};
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
@@ -48,7 +47,6 @@ loader_hack!(Menu);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/menu)
 pub struct MatMenu {
-    props: MenuProps,
     node_ref: NodeRef,
     opened_listener: Option<EventListener>,
     closed_listener: Option<EventListener>,
@@ -60,7 +58,7 @@ pub struct MatMenu {
 ///
 /// MWC Documentation [properties](https://github.com/material-components/material-components-web-components/tree/master/packages/menu#propertiesattributes)
 /// and [events](https://github.com/material-components/material-components-web-components/tree/master/packages/menu#events)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct MenuProps {
     /// Changing this prop re-renders the component.
     /// For general usage, consider using `show` method provided by
@@ -92,7 +90,7 @@ pub struct MenuProps {
     #[prop_or_default]
     pub wrap_focus: bool,
     #[prop_or_default]
-    pub inner_role: Cow<'static, str>,
+    pub inner_role: String,
     #[prop_or_default]
     pub multi: bool,
     #[prop_or_default]
@@ -135,11 +133,13 @@ impl Component for MatMenu {
     type Message = ();
     type Properties = MenuProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        props.menu_link.borrow_mut().replace(link);
+    fn create(ctx: &Context<Self>) -> Self {
+        ctx.props()
+            .menu_link
+            .borrow_mut()
+            .replace(ctx.link().clone());
         Menu::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             opened_listener: None,
             closed_listener: None,
@@ -148,70 +148,63 @@ impl Component for MatMenu {
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-menu
-                open=self.props.open
-                corner=to_option_string(self.props.corner.to_string())
-                menuCorner=to_option_string(self.props.menu_corner.to_string())
-                quick=bool_to_option(self.props.quick)
-                absolute=bool_to_option(self.props.absolute)
-                fixed=bool_to_option(self.props.fixed)
-                x=self.props.x.map(|it| Cow::from(it.to_string()))
-                y=self.props.y.map(|it| Cow::from(it.to_string()))
-                forceGroupSelection=bool_to_option(self.props.force_group_selection)
-                defaultFocus=to_option_string(self.props.default_focus.to_string())
-                fullwidth=bool_to_option(self.props.fullwidth)
-                wrapFocus=bool_to_option(self.props.wrap_focus)
-                innerRole=self.props.inner_role.clone()
-                multi=bool_to_option(self.props.multi)
-                activatable=bool_to_option(self.props.activatable)
-                ref=self.node_ref.clone()
-            >
-              { self.props.children.clone() }
-            </mwc-menu>
+             <mwc-menu
+                 open={props.open}
+                 corner={to_option_string(props.corner.to_string())}
+                 menuCorner={to_option_string(props.menu_corner.to_string())}
+                 quick={bool_to_option(props.quick)}
+                 absolute={bool_to_option(props.absolute)}
+                 fixed={bool_to_option(props.fixed)}
+                 x={props.x.map(|it| it.to_string())}
+                 y={props.y.map(|it| it.to_string())}
+                 forceGroupSelection={bool_to_option(props.force_group_selection)}
+                 defaultFocus={to_option_string(props.default_focus.to_string())}
+                 fullwidth={bool_to_option(props.fullwidth)}
+                 wrapFocus={bool_to_option(props.wrap_focus)}
+                 innerRole={props.inner_role.clone()}
+                 multi={bool_to_option(props.multi)}
+                 activatable={bool_to_option(props.activatable)}
+                 ref={self.node_ref.clone()}
+             >
+               {props.children.clone()}
+             </mwc-menu>
         }
     }
 
-    fn rendered(&mut self, first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
+        let props = ctx.props();
         let menu = self.node_ref.cast::<Menu>().unwrap();
         if first_render {
-            if let Some(anchor) = self.props.anchor.as_ref() {
+            if let Some(anchor) = props.anchor.as_ref() {
                 menu.set_anchor(anchor);
             }
         }
         if self.opened_listener.is_none() {
-            let onopened = self.props.onopened.clone();
+            let onopened = props.onopened.clone();
             self.opened_listener = Some(EventListener::new(&menu, "opened", move |_| {
                 onopened.emit(());
             }));
         }
 
         if self.closed_listener.is_none() {
-            let onclosed = self.props.onclosed.clone();
+            let onclosed = props.onclosed.clone();
             self.closed_listener = Some(EventListener::new(&menu, "closed", move |_| {
                 onclosed.emit(());
             }));
         }
 
         if self.selected_listener.is_none() {
-            let onselected = self.props.onselected.clone();
+            let onselected = props.onselected.clone();
             self.selected_listener = Some(EventListener::new(&menu, "selected", move |event| {
                 onselected.emit(SelectedDetail::from(event_into_details(event)));
             }));
         }
 
         if self.action_listener.is_none() {
-            let onaction = self.props.onaction.clone();
+            let onaction = props.onaction.clone();
             self.action_listener = Some(EventListener::new(&menu.clone(), "action", move |_| {
                 let val: JsValue = menu.index();
 

--- a/material-yew/src/menu/models.rs
+++ b/material-yew/src/menu/models.rs
@@ -1,7 +1,7 @@
 /// The `Corner` type
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/menu#propertiesattributes)
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum Corner {
     TopLeft,
     TopRight,
@@ -33,7 +33,7 @@ impl ToString for Corner {
 /// The `MenuCorner` type
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/menu#propertiesattributes)
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum MenuCorner {
     Start,
     End,
@@ -53,7 +53,7 @@ impl ToString for MenuCorner {
 /// The `DefaultFocusState` type
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/menu#propertiesattributes)
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum DefaultFocusState {
     None,
     ListRoot,

--- a/material-yew/src/radio.rs
+++ b/material-yew/src/radio.rs
@@ -1,6 +1,5 @@
 use crate::bool_to_option;
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
@@ -27,7 +26,6 @@ loader_hack!(Radio);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/radio)
 pub struct MatRadio {
-    props: RadioProps,
     node_ref: NodeRef,
     change_listener: Option<EventListener>,
 }
@@ -38,16 +36,16 @@ pub struct MatRadio {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/radio#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/radio#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct RadioProps {
     #[prop_or_default]
     pub checked: bool,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
-    pub name: Cow<'static, str>,
+    pub name: String,
     #[prop_or_default]
-    pub value: Cow<'static, str>,
+    pub value: String,
     #[prop_or_default]
     pub global: bool,
     #[prop_or_default]
@@ -65,43 +63,35 @@ impl Component for MatRadio {
     type Message = ();
     type Properties = RadioProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Radio::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             change_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-              <mwc-radio
-                  disabled=self.props.disabled
-                  name=self.props.name.clone()
-                  value=self.props.value.clone()
-                  global=bool_to_option(self.props.global)
-                  reducedTouchTarget=bool_to_option(self.props.reduced_touch_target)
-                  ref=self.node_ref.clone()
-              ></mwc-radio>
+               <mwc-radio
+                   disabled={props.disabled}
+                   name={props.name.clone()}
+                   value={props.value.clone()}
+                   global={bool_to_option(props.global)}
+                   reducedTouchTarget={bool_to_option(props.reduced_touch_target)}
+                   ref={self.node_ref.clone()}
+               ></mwc-radio>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Radio>().unwrap();
-        element.set_checked(self.props.checked);
+        element.set_checked(props.checked);
 
         if self.change_listener.is_none() {
-            let callback = self.props.onchange.clone();
+            let callback = props.onchange.clone();
             self.change_listener =
                 Some(EventListener::new(&element.clone(), "change", move |_| {
                     callback.emit(element.checked());

--- a/material-yew/src/radio.rs
+++ b/material-yew/src/radio.rs
@@ -3,6 +3,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-radio.js")]
 extern "C" {
@@ -43,9 +44,9 @@ pub struct RadioProps {
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
-    pub name: String,
+    pub name: Option<AttrValue>,
     #[prop_or_default]
-    pub value: String,
+    pub value: Option<AttrValue>,
     #[prop_or_default]
     pub global: bool,
     #[prop_or_default]

--- a/material-yew/src/select.rs
+++ b/material-yew/src/select.rs
@@ -10,6 +10,7 @@ use gloo::events::EventListener;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-select.js")]
 extern "C" {
@@ -54,25 +55,25 @@ pub struct MatSelect {
 #[derive(Properties, PartialEq, Clone)]
 pub struct Props {
     #[prop_or_default]
-    pub value: String,
+    pub value: Option<AttrValue>,
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
     pub natural_menu_width: bool,
     #[prop_or_default]
-    pub icon: String,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
     pub outlined: bool,
     #[prop_or_default]
-    pub helper: String,
+    pub helper: Option<AttrValue>,
     #[prop_or_default]
     pub required: bool,
     #[prop_or_default]
-    pub validation_message: String,
+    pub validation_message: Option<AttrValue>,
     #[prop_or_default]
-    pub items: String,
+    pub items: Option<AttrValue>,
     #[prop_or(- 1)]
     pub index: i64,
     #[prop_or_default]

--- a/material-yew/src/select.rs
+++ b/material-yew/src/select.rs
@@ -164,7 +164,7 @@ impl Component for MatSelect {
                     },
                 )
                     as Box<dyn Fn(String, NativeValidityState) -> ValidityStateJS>));
-                element.set_validity_transform(&self.validity_transform_closure.as_ref().unwrap());
+                element.set_validity_transform(self.validity_transform_closure.as_ref().unwrap());
             }
         }
 

--- a/material-yew/src/select.rs
+++ b/material-yew/src/select.rs
@@ -7,7 +7,6 @@ use crate::text_inputs::{
 use crate::utils::WeakComponentLink;
 use crate::{bool_to_option, event_into_details, to_option_string};
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Node;
 use yew::prelude::*;
@@ -37,7 +36,6 @@ loader_hack!(Select);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/select)
 pub struct MatSelect {
-    props: Props,
     node_ref: NodeRef,
     validity_transform_closure:
         Option<Closure<dyn Fn(String, NativeValidityState) -> ValidityStateJS>>,
@@ -53,28 +51,28 @@ pub struct MatSelect {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/select#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/select#events)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct Props {
     #[prop_or_default]
-    pub value: Cow<'static, str>,
+    pub value: String,
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
     pub natural_menu_width: bool,
     #[prop_or_default]
-    pub icon: Cow<'static, str>,
+    pub icon: String,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
     pub outlined: bool,
     #[prop_or_default]
-    pub helper: Cow<'static, str>,
+    pub helper: String,
     #[prop_or_default]
     pub required: bool,
     #[prop_or_default]
-    pub validation_message: Cow<'static, str>,
+    pub validation_message: String,
     #[prop_or_default]
-    pub items: Cow<'static, str>,
+    pub items: String,
     #[prop_or(- 1)]
     pub index: i64,
     #[prop_or_default]
@@ -115,11 +113,13 @@ impl Component for MatSelect {
     type Message = ();
     type Properties = Props;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        props.select_link.borrow_mut().replace(link);
+    fn create(ctx: &Context<Self>) -> Self {
+        ctx.props()
+            .select_link
+            .borrow_mut()
+            .replace(ctx.link().clone());
         Select::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             validity_transform_closure: None,
             opened_listener: None,
@@ -129,42 +129,35 @@ impl Component for MatSelect {
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-select
-                value=self.props.value.clone()
-                label=self.props.label.clone()
-                naturalMenuWidth=bool_to_option(self.props.natural_menu_width)
-                icon=self.props.icon.clone()
-                disabled=self.props.disabled
-                outlined=bool_to_option(self.props.outlined)
-                helper=self.props.helper.clone()
-                required=self.props.required
-                validationMessage=self.props.validation_message.clone()
-                items=self.props.items.clone()
-                index=to_option_string(self.props.index)
-                validateOnInitialRender=bool_to_option(self.props.validate_on_initial_render)
-                ref=self.node_ref.clone()
-            >
-              { self.props.children.clone() }
-            </mwc-select>
+             <mwc-select
+                 value={props.value.clone()}
+                 label={props.label.clone()}
+                 naturalMenuWidth={bool_to_option(props.natural_menu_width)}
+                 icon={props.icon.clone()}
+                 disabled={props.disabled}
+                 outlined={bool_to_option(props.outlined)}
+                 helper={props.helper.clone()}
+                 required={props.required}
+                 validationMessage={props.validation_message.clone()}
+                 items={props.items.clone()}
+                 index={to_option_string(props.index)}
+                 validateOnInitialRender={bool_to_option(props.validate_on_initial_render)}
+                 ref={self.node_ref.clone()}
+             >
+               {props.children.clone()}
+             </mwc-select>
         }
     }
 
     //noinspection DuplicatedCode
-    fn rendered(&mut self, first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Select>().unwrap();
         if first_render {
-            if let Some(transform) = self.props.validity_transform.clone() {
+            if let Some(transform) = props.validity_transform.clone() {
                 self.validity_transform_closure = Some(Closure::wrap(Box::new(
                     move |s: String, v: NativeValidityState| -> ValidityStateJS {
                         transform.0(s, v).into()
@@ -176,28 +169,28 @@ impl Component for MatSelect {
         }
 
         if self.opened_listener.is_none() {
-            let onopened = self.props.onopened.clone();
+            let onopened = props.onopened.clone();
             self.opened_listener = Some(EventListener::new(&element, "opened", move |_| {
                 onopened.emit(())
             }));
         }
 
         if self.closed_listener.is_none() {
-            let onclosed = self.props.onclosed.clone();
+            let onclosed = props.onclosed.clone();
             self.closed_listener = Some(EventListener::new(&element, "closed", move |_| {
                 onclosed.emit(())
             }));
         }
 
         if self.action_listener.is_none() {
-            let on_action = self.props.onaction.clone();
+            let on_action = props.onaction.clone();
             self.action_listener = Some(EventListener::new(&element, "action", move |event| {
                 on_action.emit(ActionDetail::from(event_into_details(event)))
             }));
         }
 
         if self.selected_listener.is_none() {
-            let on_selected = self.props.onselected.clone();
+            let on_selected = props.onselected.clone();
             self.selected_listener = Some(EventListener::new(&element, "selected", move |event| {
                 on_selected.emit(SelectedDetail::from(event_into_details(event)))
             }));

--- a/material-yew/src/slider.rs
+++ b/material-yew/src/slider.rs
@@ -22,7 +22,6 @@ loader_hack!(Slider);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/slider)
 pub struct MatSlider {
-    props: SliderProps,
     node_ref: NodeRef,
     input_listener: Option<EventListener>,
     change_listener: Option<EventListener>,
@@ -34,7 +33,7 @@ pub struct MatSlider {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/slider#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/slider#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct SliderProps {
     #[prop_or(0)]
     pub value: u32,
@@ -64,50 +63,42 @@ impl Component for MatSlider {
     type Message = ();
     type Properties = SliderProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Slider::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             input_listener: None,
             change_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-slider
-                value=to_option_string(self.props.value)
-                min=to_option_string(self.props.min)
-                max=to_option_string(self.props.max)
-                step=to_option_string(self.props.step)
-                pin=bool_to_option(self.props.pin)
-                markers=bool_to_option(self.props.markers)
-                ref=self.node_ref.clone()
-            ></mwc-slider>
+             <mwc-slider
+                 value={to_option_string(props.value)}
+                 min={to_option_string(props.min)}
+                 max={to_option_string(props.max)}
+                 step={to_option_string(props.step)}
+                 pin={bool_to_option(props.pin)}
+                 markers={bool_to_option(props.markers)}
+                 ref={self.node_ref.clone()}
+             ></mwc-slider>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Element>().unwrap();
         if self.input_listener.is_none() {
-            let oninput = self.props.oninput.clone();
+            let oninput = props.oninput.clone();
             self.input_listener = Some(EventListener::new(&element, "input", move |event| {
                 oninput.emit(JsValue::from(event).unchecked_into::<CustomEvent>())
             }));
         };
 
         if self.change_listener.is_none() {
-            let onchange = self.props.onchange.clone();
+            let onchange = props.onchange.clone();
             self.change_listener = Some(EventListener::new(&element, "change", move |event| {
                 onchange.emit(JsValue::from(event).unchecked_into::<CustomEvent>())
             }));

--- a/material-yew/src/snackbar.rs
+++ b/material-yew/src/snackbar.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::Node;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-snackbar.js")]
 extern "C" {
@@ -63,7 +64,7 @@ pub struct SnackbarProps {
     #[prop_or_default]
     pub close_on_escape: bool,
     #[prop_or_default]
-    pub label_text: String,
+    pub label_text: Option<AttrValue>,
     #[prop_or_default]
     pub stacked: bool,
     #[prop_or_default]

--- a/material-yew/src/snackbar.rs
+++ b/material-yew/src/snackbar.rs
@@ -1,7 +1,6 @@
 use crate::{bool_to_option, event_into_details, to_option_string, WeakComponentLink};
 use gloo::events::EventListener;
 use js_sys::Object;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::Node;
@@ -42,7 +41,6 @@ loader_hack!(Snackbar);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/snackbar)
 pub struct MatSnackbar {
-    props: SnackbarProps,
     node_ref: NodeRef,
     opening_listener: Option<EventListener>,
     opened_listener: Option<EventListener>,
@@ -56,7 +54,7 @@ pub struct MatSnackbar {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/snackbar#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/snackbar#events)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct SnackbarProps {
     #[prop_or_default]
     pub open: bool,
@@ -65,7 +63,7 @@ pub struct SnackbarProps {
     #[prop_or_default]
     pub close_on_escape: bool,
     #[prop_or_default]
-    pub label_text: Cow<'static, str>,
+    pub label_text: String,
     #[prop_or_default]
     pub stacked: bool,
     #[prop_or_default]
@@ -111,11 +109,13 @@ impl Component for MatSnackbar {
     type Message = ();
     type Properties = SnackbarProps;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        props.snackbar_link.borrow_mut().replace(link);
+    fn create(ctx: &Context<Self>) -> Self {
+        ctx.props()
+            .snackbar_link
+            .borrow_mut()
+            .replace(ctx.link().clone());
         Snackbar::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             opening_listener: None,
             opened_listener: None,
@@ -124,34 +124,27 @@ impl Component for MatSnackbar {
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-snackbar
-                timeoutMs=to_option_string(self.props.timeout_ms)
-                closeOnEscape=to_option_string(self.props.close_on_escape)
-                labelText=self.props.label_text.clone()
-                stacked=bool_to_option(self.props.stacked)
-                leading=bool_to_option(self.props.leading)
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-snackbar>
+             <mwc-snackbar
+                 timeoutMs={to_option_string(props.timeout_ms)}
+                 closeOnEscape={to_option_string(props.close_on_escape)}
+                 labelText={props.label_text.clone()}
+                 stacked={bool_to_option(props.stacked)}
+                 leading={bool_to_option(props.leading)}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-snackbar>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Snackbar>().unwrap();
-        element.set_open(self.props.open);
+        element.set_open(props.open);
 
         if self.opening_listener.is_none() {
-            let on_opening = self.props.onopening.clone();
+            let on_opening = props.onopening.clone();
             self.opening_listener = Some(EventListener::new(
                 &element,
                 "MDCSnackbar:opening",
@@ -162,7 +155,7 @@ impl Component for MatSnackbar {
         };
 
         if self.opened_listener.is_none() {
-            let on_opened = self.props.onopened.clone();
+            let on_opened = props.onopened.clone();
             self.opened_listener = Some(EventListener::new(
                 &element,
                 "MDCSnackbar:opened",
@@ -173,7 +166,7 @@ impl Component for MatSnackbar {
         };
 
         if self.closing_listener.is_none() {
-            let on_closing = self.props.onclosing.clone();
+            let on_closing = props.onclosing.clone();
             self.closing_listener = Some(EventListener::new(
                 &element,
                 "MDCSnackbar:closing",
@@ -184,7 +177,7 @@ impl Component for MatSnackbar {
         }
 
         if self.closed_listener.is_none() {
-            let on_closed = self.props.onclosed.clone();
+            let on_closed = props.onclosed.clone();
             self.closed_listener = Some(EventListener::new(
                 &element,
                 "MDCSnackbar:closed",

--- a/material-yew/src/switch.rs
+++ b/material-yew/src/switch.rs
@@ -25,7 +25,6 @@ loader_hack!(Switch);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/switch)
 pub struct MatSwitch {
-    props: SwitchProps,
     node_ref: NodeRef,
     change_listener: Option<EventListener>,
 }
@@ -36,7 +35,7 @@ pub struct MatSwitch {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/switch#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/switch#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct SwitchProps {
     #[prop_or_default]
     pub checked: bool,
@@ -53,39 +52,31 @@ impl Component for MatSwitch {
     type Message = ();
     type Properties = SwitchProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Switch::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             change_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-              <mwc-switch
-                  disabled=self.props.disabled
-                  ref=self.node_ref.clone()
-              ></mwc-switch>
+               <mwc-switch
+                   disabled={props.disabled}
+                   ref={self.node_ref.clone()}
+               ></mwc-switch>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<Switch>().unwrap();
-        element.set_checked(self.props.checked);
+        element.set_checked(props.checked);
 
         if self.change_listener.is_none() {
-            let callback = self.props.onchange.clone();
+            let callback = props.onchange.clone();
             self.change_listener =
                 Some(EventListener::new(&element.clone(), "change", move |_| {
                     callback.emit(element.checked());

--- a/material-yew/src/tabs/tab.rs
+++ b/material-yew/src/tabs/tab.rs
@@ -1,7 +1,6 @@
 use crate::{bool_to_option, event_details_into};
 use gloo::events::EventListener;
 use js_sys::Object;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use web_sys::Element;
 use yew::prelude::*;
@@ -21,7 +20,6 @@ loader_hack!(Tab);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/tab)
 pub struct MatTab {
-    props: TabProps,
     node_ref: NodeRef,
     interacted_listener: Option<EventListener>,
 }
@@ -30,16 +28,16 @@ pub struct MatTab {
 ///
 /// MWC Documentation [properties](https://github.com/material-components/material-components-web-components/tree/master/packages/tab#propertiesattributes)
 /// and [events](https://github.com/material-components/material-components-web-components/tree/master/packages/tab#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct TabProps {
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
-    pub icon: Cow<'static, str>,
+    pub icon: String,
     #[prop_or_default]
     pub has_image_icon: bool,
     #[prop_or_default]
-    pub indicator_icon: Cow<'static, str>,
+    pub indicator_icon: String,
     #[prop_or_default]
     pub is_fading_indicator: bool,
     #[prop_or_default]
@@ -61,45 +59,37 @@ impl Component for MatTab {
     type Message = ();
     type Properties = TabProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Tab::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             interacted_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-tab
-                label=self.props.label.clone()
-                icon=self.props.icon.clone()
-                hasImageIcon=bool_to_option(self.props.has_image_icon)
-                indicatorIcon=self.props.indicator_icon.clone()
-                isFadingIndicator=bool_to_option(self.props.is_fading_indicator)
-                minWidth=bool_to_option(self.props.min_width)
-                isMinWidthIndicator=bool_to_option(self.props.is_min_width_indicator)
-                stacked=bool_to_option(self.props.stacked)
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-tab>
+             <mwc-tab
+                 label={props.label.clone()}
+                 icon={props.icon.clone()}
+                 hasImageIcon={bool_to_option(props.has_image_icon)}
+                 indicatorIcon={props.indicator_icon.clone()}
+                 isFadingIndicator={bool_to_option(props.is_fading_indicator)}
+                 minWidth={bool_to_option(props.min_width)}
+                 isMinWidthIndicator={bool_to_option(props.is_min_width_indicator)}
+                 stacked={bool_to_option(props.stacked)}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-tab>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.interacted_listener.is_none() {
             let element = self.node_ref.cast::<Element>().unwrap();
 
-            let on_interacted = self.props.oninteracted.clone();
+            let on_interacted = props.oninteracted.clone();
             self.interacted_listener = Some(EventListener::new(
                 &element,
                 "MDCTab:interacted",

--- a/material-yew/src/tabs/tab.rs
+++ b/material-yew/src/tabs/tab.rs
@@ -4,6 +4,7 @@ use js_sys::Object;
 use wasm_bindgen::prelude::*;
 use web_sys::Element;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-tab.js")]
 extern "C" {
@@ -31,13 +32,13 @@ pub struct MatTab {
 #[derive(Debug, Properties, PartialEq, Clone)]
 pub struct TabProps {
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
-    pub icon: String,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
     pub has_image_icon: bool,
     #[prop_or_default]
-    pub indicator_icon: String,
+    pub indicator_icon: Option<AttrValue>,
     #[prop_or_default]
     pub is_fading_indicator: bool,
     #[prop_or_default]

--- a/material-yew/src/tabs/tab_bar.rs
+++ b/material-yew/src/tabs/tab_bar.rs
@@ -20,7 +20,6 @@ loader_hack!(TabBar);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/tab-bar)
 pub struct MatTabBar {
-    props: TabBarProps,
     node_ref: NodeRef,
     activated_listener: Option<EventListener>,
 }
@@ -29,7 +28,7 @@ pub struct MatTabBar {
 ///
 /// MWC Documentation [properties](https://github.com/material-components/material-components-web-components/tree/master/packages/tab-bar#propertiesattributes)
 /// and [events](https://github.com/material-components/material-components-web-components/tree/master/packages/tab-bar#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct TabBarProps {
     #[prop_or_default]
     pub active_index: u32,
@@ -46,38 +45,30 @@ impl Component for MatTabBar {
     type Message = ();
     type Properties = TabBarProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         TabBar::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             activated_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-tab-bar
-                activeIndex=to_option_string(self.props.active_index)
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-tab-bar>
+             <mwc-tab-bar
+                 activeIndex={to_option_string(props.active_index)}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-tab-bar>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.activated_listener.is_none() {
             let element = self.node_ref.cast::<Element>().unwrap();
 
-            let on_activated = self.props.onactivated.clone();
+            let on_activated = props.onactivated.clone();
             self.activated_listener = Some(EventListener::new(
                 &element,
                 "MDCTabBar:activated",

--- a/material-yew/src/tabs/tab_icon.rs
+++ b/material-yew/src/tabs/tab_icon.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "icon";
 
 /// Props for [`MatTabIcon`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct TabIconProps {
     pub children: Children,
 }
@@ -13,30 +13,19 @@ pub struct TabIconProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTabIcon {
-    props: TabIconProps,
-}
+pub struct MatTabIcon;
 
 impl Component for MatTabIcon {
     type Message = ();
     type Properties = TabIconProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -47,9 +36,9 @@ impl Component for MatTabIcon {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -57,7 +46,7 @@ impl Component for MatTabIcon {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/tabs/tab_icon.rs
+++ b/material-yew/src/tabs/tab_icon.rs
@@ -13,14 +13,14 @@ pub struct TabIconProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTabIcon;
+pub struct MatTabIcon {}
 
 impl Component for MatTabIcon {
     type Message = ();
     type Properties = TabIconProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/text_inputs/mod.rs
+++ b/material-yew/src/text_inputs/mod.rs
@@ -46,6 +46,7 @@ impl ValidityTransform {
 }
 
 impl PartialEq for ValidityTransform {
+    #[allow(clippy::vtable_address_comparisons)]
     fn eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.0, &other.0)
     }

--- a/material-yew/src/text_inputs/mod.rs
+++ b/material-yew/src/text_inputs/mod.rs
@@ -26,7 +26,7 @@ use std::rc::Rc;
 use gloo::events::EventListener;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{Element, Event, InputEvent};
-use yew::{Callback, InputData, NodeRef};
+use yew::{Callback, NodeRef};
 
 #[cfg(any(feature = "textfield", feature = "textarea"))]
 pub(crate) type ValidityTransformFn = dyn Fn(String, NativeValidityState) -> ValidityState;
@@ -45,20 +45,25 @@ impl ValidityTransform {
     }
 }
 
+impl PartialEq for ValidityTransform {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
 fn set_on_input_handler(
     node_ref: &NodeRef,
-    callback: Callback<InputData>,
-    convert: impl Fn((InputEvent, JsValue)) -> InputData + 'static,
+    callback: Callback<String>,
+    convert: impl Fn((InputEvent, JsValue)) -> String + 'static,
 ) -> EventListener {
     let element = node_ref.cast::<Element>().unwrap();
     EventListener::new(&element, "input", move |event: &Event| {
         let js_value = JsValue::from(event);
 
-        let input_event = js_value
-            .clone()
-            .dyn_into::<web_sys::InputEvent>()
-            .expect("could not convert to `InputEvent`");
-
-        callback.emit(convert((input_event, js_value)))
+        if let Some(input_event) = JsCast::dyn_ref::<web_sys::InputEvent>(&js_value) {
+            callback.emit(convert((input_event.clone(), js_value)))
+        } else {
+            panic!("could not convert to `InputEvent`");
+        }
     })
 }

--- a/material-yew/src/text_inputs/text_field_type.rs
+++ b/material-yew/src/text_inputs/text_field_type.rs
@@ -1,7 +1,5 @@
-use std::borrow::Cow;
-
 /// The `TextFieldType` type
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TextFieldType {
     Text,
     Search,
@@ -19,9 +17,9 @@ pub enum TextFieldType {
 }
 
 impl TextFieldType {
-    pub fn to_cow_string(&self) -> Cow<'static, str> {
+    pub fn as_str(&self) -> &'static str {
         use TextFieldType::*;
-        let s = match self {
+        match self {
             Text => "text",
             Search => "search",
             Tel => "tel",
@@ -35,7 +33,6 @@ impl TextFieldType {
             DatetimeLocal => "datetime-local",
             Number => "number",
             Color => "color",
-        };
-        Cow::from(s)
+        }
     }
 }

--- a/material-yew/src/text_inputs/textarea.rs
+++ b/material-yew/src/text_inputs/textarea.rs
@@ -8,6 +8,7 @@ use wasm_bindgen::JsCast;
 use web_sys::Node;
 pub use web_sys::ValidityState as NativeValidityState;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-textarea.js")]
 extern "C" {
@@ -77,17 +78,17 @@ pub struct TextAreaProps {
     #[prop_or_default]
     pub cols: Option<i64>,
     #[prop_or_default]
-    pub value: String,
+    pub value: Option<AttrValue>,
     #[prop_or(TextFieldType::Text)]
     pub field_type: TextFieldType,
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
-    pub placeholder: String,
+    pub placeholder: Option<AttrValue>,
     #[prop_or_default]
-    pub icon: String,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
-    pub icon_trailing: String,
+    pub icon_trailing: Option<AttrValue>,
     #[prop_or_default]
     pub disabled: bool,
     /// For boolean value `true`, `TextAreaCharCounter::External` is to be used.
@@ -98,7 +99,7 @@ pub struct TextAreaProps {
     #[prop_or_default]
     pub outlined: bool,
     #[prop_or_default]
-    pub helper: String,
+    pub helper: Option<AttrValue>,
     #[prop_or_default]
     pub helper_persistent: bool,
     #[prop_or_default]
@@ -106,13 +107,13 @@ pub struct TextAreaProps {
     #[prop_or_default]
     pub max_length: Option<u64>,
     #[prop_or_default]
-    pub validation_message: String,
+    pub validation_message: Option<AttrValue>,
     /// Type: `number | string` so I'll leave it as a string
     #[prop_or_default]
-    pub min: String,
+    pub min: Option<AttrValue>,
     /// Type: `number | string`  so I'll leave it as a string
     #[prop_or_default]
-    pub max: String,
+    pub max: Option<AttrValue>,
     #[prop_or_default]
     pub size: Option<i64>, // --|
     #[prop_or_default] //   | -- What you doing step size
@@ -126,7 +127,7 @@ pub struct TextAreaProps {
     #[prop_or_default]
     pub oninput: Callback<String>,
     #[prop_or_default]
-    pub name: String,
+    pub name: Option<AttrValue>,
 }
 
 impl Component for MatTextArea {
@@ -176,7 +177,9 @@ impl Component for MatTextArea {
         let props = ctx.props();
         let element = self.node_ref.cast::<TextArea>().unwrap();
         element.set_type(&JsValue::from(props.field_type.as_str()));
-        element.set_value(&JsValue::from_str(props.value.as_ref()));
+        element.set_value(&JsValue::from_str(
+            props.value.as_ref().map(|s| s.as_ref()).unwrap_or_default(),
+        ));
 
         if self.input_listener.is_none() {
             self.input_listener = Some(set_on_input_handler(

--- a/material-yew/src/text_inputs/textarea.rs
+++ b/material-yew/src/text_inputs/textarea.rs
@@ -183,12 +183,10 @@ impl Component for MatTextArea {
                 &self.node_ref,
                 props.oninput.clone(),
                 |(_, detail)| {
-                    let value = detail
+                    detail
                         .unchecked_into::<MatTextAreaInputEvent>()
                         .target()
-                        .value();
-
-                    value.to_string()
+                        .value()
                 },
             ));
         };
@@ -202,7 +200,7 @@ impl Component for MatTextArea {
                     },
                 )
                     as Box<dyn Fn(String, NativeValidityState) -> ValidityStateJS>));
-                this.set_validity_transform(&self.validity_transform_closure.as_ref().unwrap());
+                this.set_validity_transform(self.validity_transform_closure.as_ref().unwrap());
             }
         }
     }

--- a/material-yew/src/text_inputs/textfield.rs
+++ b/material-yew/src/text_inputs/textfield.rs
@@ -4,7 +4,6 @@ use crate::text_inputs::{
     validity_state::ValidityStateJS, TextFieldType, ValidityState, ValidityTransform,
 };
 use gloo::events::EventListener;
-use std::borrow::Cow;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::Node;
@@ -42,7 +41,6 @@ loader_hack!(TextField);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/textfield)
 pub struct MatTextField {
-    props: TextFieldProps,
     node_ref: NodeRef,
     validity_transform_closure:
         Option<Closure<dyn Fn(String, NativeValidityState) -> ValidityStateJS>>,
@@ -54,26 +52,26 @@ pub struct MatTextField {
 /// MWC Documentation:
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/textfield#propertiesattributes)
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct TextFieldProps {
     #[prop_or_default]
     pub open: bool,
     #[prop_or_default]
-    pub value: Cow<'static, str>,
+    pub value: String,
     #[prop_or(TextFieldType::Text)]
     pub field_type: TextFieldType,
     #[prop_or_default]
-    pub label: Cow<'static, str>,
+    pub label: String,
     #[prop_or_default]
-    pub placeholder: Cow<'static, str>,
+    pub placeholder: String,
     #[prop_or_default]
-    pub prefix: Cow<'static, str>,
+    pub prefix: String,
     #[prop_or_default]
-    pub suffix: Cow<'static, str>,
+    pub suffix: String,
     #[prop_or_default]
-    pub icon: Cow<'static, str>,
+    pub icon: String,
     #[prop_or_default]
-    pub icon_trailing: Cow<'static, str>,
+    pub icon_trailing: String,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
@@ -81,7 +79,7 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub outlined: bool,
     #[prop_or_default]
-    pub helper: Cow<'static, str>,
+    pub helper: String,
     #[prop_or_default]
     pub helper_persistent: bool,
     #[prop_or_default]
@@ -89,15 +87,15 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub max_length: Option<u64>,
     #[prop_or_default]
-    pub validation_message: Cow<'static, str>,
+    pub validation_message: String,
     #[prop_or_default]
-    pub pattern: Cow<'static, str>,
+    pub pattern: String,
     /// Type: `number | string` so I'll leave it as a string
     #[prop_or_default]
-    pub min: Cow<'static, str>,
+    pub min: String,
     /// Type: `number | string`  so I'll leave it as a string
     #[prop_or_default]
-    pub max: Cow<'static, str>,
+    pub max: String,
     // What you doing...
     #[prop_or_default]
     pub size: Option<i64>,
@@ -111,90 +109,80 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub validate_on_initial_render: bool,
     #[prop_or_default]
-    pub oninput: Callback<InputData>,
+    pub oninput: Callback<String>,
     #[prop_or_default]
-    pub name: Cow<'static, str>,
+    pub name: String,
 }
 
 impl Component for MatTextField {
     type Message = ();
     type Properties = TextFieldProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         TextField::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             validity_transform_closure: None,
             input_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-textfield
-                open=self.props.open
-                label=self.props.label.clone()
-                placeholder=self.props.placeholder.clone()
-                prefix=self.props.prefix.clone()
-                suffix=self.props.suffix.clone()
-                icon=self.props.icon.clone()
-                iconTrailing=self.props.icon_trailing.clone()
-                disabled=self.props.disabled
-                charCounter=bool_to_option(self.props.char_counter)
-                outlined=bool_to_option(self.props.outlined)
-                helper=self.props.helper.clone()
-                helperPersistent=bool_to_option(self.props.helper_persistent)
-                required=self.props.required
-                maxLength=self.props.max_length.map(|v| Cow::from(v.to_string()))
-                validationMessage=self.props.validation_message.clone()
-                pattern=self.props.pattern.clone()
-                min=self.props.min.clone()
-                max=self.props.max.clone()
-                size=self.props.size.map(|v| Cow::from(v.to_string()))
-                step=self.props.step.map(|v| Cow::from(v.to_string()))
-                autoValidate=bool_to_option(self.props.auto_validate)
-                validateOnInitialRender=bool_to_option(self.props.validate_on_initial_render)
-                name=self.props.name.clone()
-                ref=self.node_ref.clone()
-            ></mwc-textfield>
+             <mwc-textfield
+                 open={props.open}
+                 label={props.label.clone()}
+                 placeholder={props.placeholder.clone()}
+                 prefix={props.prefix.clone()}
+                 suffix={props.suffix.clone()}
+                 icon={props.icon.clone()}
+                 iconTrailing={props.icon_trailing.clone()}
+                 disabled={props.disabled}
+                 charCounter={bool_to_option(props.char_counter)}
+                 outlined={bool_to_option(props.outlined)}
+                 helper={props.helper.clone()}
+                 helperPersistent={bool_to_option(props.helper_persistent)}
+                 required={props.required}
+                 maxLength={props.max_length.map(|v| v.to_string())}
+                 validationMessage={props.validation_message.clone()}
+                 pattern={props.pattern.clone()}
+                 min={props.min.clone()}
+                 max={props.max.clone()}
+                 size={props.size.map(|v| v.to_string())}
+                 step={props.step.map(|v| v.to_string())}
+                 autoValidate={bool_to_option(props.auto_validate)}
+                 validateOnInitialRender={bool_to_option(props.validate_on_initial_render)}
+                 name={props.name.clone()}
+                 ref={self.node_ref.clone()}
+             ></mwc-textfield>
         }
     }
 
-    fn rendered(&mut self, first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
+        let props = ctx.props();
         let element = self.node_ref.cast::<TextField>().unwrap();
-        element.set_type(&JsValue::from(
-            self.props.field_type.to_cow_string().as_ref(),
-        ));
-        element.set_value(&JsValue::from(self.props.value.as_ref()));
+        element.set_type(&JsValue::from(props.field_type.as_str()));
+        element.set_value(&JsValue::from_str(props.value.as_ref()));
 
         if self.input_listener.is_none() {
             self.input_listener = Some(set_on_input_handler(
                 &self.node_ref,
-                self.props.oninput.clone(),
-                |(input_event, detail)| {
-                    InputData {
-                        value: detail
-                            .unchecked_into::<MatTextFieldInputEvent>()
-                            .target()
-                            .value(),
-                        event: input_event,
-                    }
+                props.oninput.clone(),
+                |(_, detail)| {
+                    // TODO: figure out what's going on here...
+                    let value = detail
+                        .unchecked_into::<MatTextFieldInputEvent>()
+                        .target()
+                        .value();
+
+                    value.to_string()
                 },
             ));
         }
         if first_render {
             let this = self.node_ref.cast::<TextField>().unwrap();
-            if let Some(transform) = self.props.validity_transform.clone() {
+            if let Some(transform) = props.validity_transform.clone() {
                 self.validity_transform_closure = Some(Closure::wrap(Box::new(
                     move |s: String, v: NativeValidityState| -> ValidityStateJS {
                         transform.0(s, v).into()

--- a/material-yew/src/text_inputs/textfield.rs
+++ b/material-yew/src/text_inputs/textfield.rs
@@ -170,13 +170,10 @@ impl Component for MatTextField {
                 &self.node_ref,
                 props.oninput.clone(),
                 |(_, detail)| {
-                    // TODO: figure out what's going on here...
-                    let value = detail
+                    detail
                         .unchecked_into::<MatTextFieldInputEvent>()
                         .target()
-                        .value();
-
-                    value.to_string()
+                        .value()
                 },
             ));
         }
@@ -189,7 +186,7 @@ impl Component for MatTextField {
                     },
                 )
                     as Box<dyn Fn(String, NativeValidityState) -> ValidityStateJS>));
-                this.set_validity_transform(&self.validity_transform_closure.as_ref().unwrap());
+                this.set_validity_transform(self.validity_transform_closure.as_ref().unwrap());
             }
         }
     }

--- a/material-yew/src/text_inputs/textfield.rs
+++ b/material-yew/src/text_inputs/textfield.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::JsCast;
 use web_sys::Node;
 use web_sys::ValidityState as NativeValidityState;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 #[wasm_bindgen(module = "/build/mwc-textfield.js")]
 extern "C" {
@@ -57,21 +58,21 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub open: bool,
     #[prop_or_default]
-    pub value: String,
+    pub value: Option<AttrValue>,
     #[prop_or(TextFieldType::Text)]
     pub field_type: TextFieldType,
     #[prop_or_default]
-    pub label: String,
+    pub label: Option<AttrValue>,
     #[prop_or_default]
-    pub placeholder: String,
+    pub placeholder: Option<AttrValue>,
     #[prop_or_default]
-    pub prefix: String,
+    pub prefix: Option<AttrValue>,
     #[prop_or_default]
-    pub suffix: String,
+    pub suffix: Option<AttrValue>,
     #[prop_or_default]
-    pub icon: String,
+    pub icon: Option<AttrValue>,
     #[prop_or_default]
-    pub icon_trailing: String,
+    pub icon_trailing: Option<AttrValue>,
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
@@ -79,7 +80,7 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub outlined: bool,
     #[prop_or_default]
-    pub helper: String,
+    pub helper: Option<AttrValue>,
     #[prop_or_default]
     pub helper_persistent: bool,
     #[prop_or_default]
@@ -87,15 +88,15 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub max_length: Option<u64>,
     #[prop_or_default]
-    pub validation_message: String,
+    pub validation_message: Option<AttrValue>,
     #[prop_or_default]
-    pub pattern: String,
+    pub pattern: Option<AttrValue>,
     /// Type: `number | string` so I'll leave it as a string
     #[prop_or_default]
-    pub min: String,
+    pub min: Option<AttrValue>,
     /// Type: `number | string`  so I'll leave it as a string
     #[prop_or_default]
-    pub max: String,
+    pub max: Option<AttrValue>,
     // What you doing...
     #[prop_or_default]
     pub size: Option<i64>,
@@ -111,7 +112,7 @@ pub struct TextFieldProps {
     #[prop_or_default]
     pub oninput: Callback<String>,
     #[prop_or_default]
-    pub name: String,
+    pub name: Option<AttrValue>,
 }
 
 impl Component for MatTextField {
@@ -163,7 +164,9 @@ impl Component for MatTextField {
         let props = ctx.props();
         let element = self.node_ref.cast::<TextField>().unwrap();
         element.set_type(&JsValue::from(props.field_type.as_str()));
-        element.set_value(&JsValue::from_str(props.value.as_ref()));
+        element.set_value(&JsValue::from_str(
+            props.value.as_ref().map(|s| s.as_ref()).unwrap_or_default(),
+        ));
 
         if self.input_listener.is_none() {
             self.input_listener = Some(set_on_input_handler(

--- a/material-yew/src/top_app_bar.rs
+++ b/material-yew/src/top_app_bar.rs
@@ -27,7 +27,6 @@ loader_hack!(TopAppBar);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar)
 pub struct MatTopAppBar {
-    props: TopAppBarProps,
     node_ref: NodeRef,
     nav_listener: Option<EventListener>,
 }
@@ -38,7 +37,7 @@ pub struct MatTopAppBar {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct TopAppBarProps {
     pub children: Children,
     #[prop_or_default]
@@ -58,40 +57,33 @@ impl Component for MatTopAppBar {
     type Message = ();
     type Properties = TopAppBarProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         TopAppBar::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             nav_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-top-app-bar
-                centerTitle=bool_to_option(self.props.center_title)
-                dense=bool_to_option(self.props.dense)
-                prominent=bool_to_option(self.props.prominent)
-                ref=self.node_ref.clone()
-            >
-                { self.props.children.clone() }
-            </mwc-top-app-bar>
+             <mwc-top-app-bar
+                 centerTitle={bool_to_option(props.center_title)}
+                 dense={bool_to_option(props.dense)}
+                 prominent={bool_to_option(props.prominent)}
+                 ref={self.node_ref.clone()}
+             >
+                 {props.children.clone()}
+             </mwc-top-app-bar>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
+
         if self.nav_listener.is_none() {
-            let callback = self.props.onnavigationiconclick.clone();
+            let callback = props.onnavigationiconclick.clone();
             let element = self.node_ref.cast::<Element>().unwrap();
 
             self.nav_listener = Some(EventListener::new(

--- a/material-yew/src/top_app_bar/action_items.rs
+++ b/material-yew/src/top_app_bar/action_items.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "actionItems";
 
 /// Props for [`MatTopAppBarActionItems`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct TopAppBarActionItemsProps {
     pub children: Children,
 }
@@ -14,30 +14,19 @@ pub struct TopAppBarActionItemsProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTopAppBarActionItems {
-    props: TopAppBarActionItemsProps,
-}
+pub struct MatTopAppBarActionItems;
 
 impl Component for MatTopAppBarActionItems {
     type Message = ();
     type Properties = TopAppBarActionItemsProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -48,9 +37,9 @@ impl Component for MatTopAppBarActionItems {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -58,7 +47,7 @@ impl Component for MatTopAppBarActionItems {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/top_app_bar/action_items.rs
+++ b/material-yew/src/top_app_bar/action_items.rs
@@ -14,14 +14,14 @@ pub struct TopAppBarActionItemsProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTopAppBarActionItems;
+pub struct MatTopAppBarActionItems {}
 
 impl Component for MatTopAppBarActionItems {
     type Message = ();
     type Properties = TopAppBarActionItemsProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/top_app_bar/navigation_icon.rs
+++ b/material-yew/src/top_app_bar/navigation_icon.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "navigationIcon";
 
 /// Props for [`MatTopAppBarNavigationIcon`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct TopAppBarNavigationIconProps {
     pub children: Children,
 }
@@ -14,30 +14,19 @@ pub struct TopAppBarNavigationIconProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTopAppBarNavigationIcon {
-    props: TopAppBarNavigationIconProps,
-}
+pub struct MatTopAppBarNavigationIcon;
 
 impl Component for MatTopAppBarNavigationIcon {
     type Message = ();
     type Properties = TopAppBarNavigationIconProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -48,9 +37,9 @@ impl Component for MatTopAppBarNavigationIcon {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -58,7 +47,7 @@ impl Component for MatTopAppBarNavigationIcon {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/top_app_bar/navigation_icon.rs
+++ b/material-yew/src/top_app_bar/navigation_icon.rs
@@ -14,14 +14,14 @@ pub struct TopAppBarNavigationIconProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTopAppBarNavigationIcon;
+pub struct MatTopAppBarNavigationIcon {}
 
 impl Component for MatTopAppBarNavigationIcon {
     type Message = ();
     type Properties = TopAppBarNavigationIconProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/top_app_bar/title.rs
+++ b/material-yew/src/top_app_bar/title.rs
@@ -3,7 +3,7 @@ use yew::prelude::*;
 const SLOT: &str = "title";
 
 /// Props for [`MatTopAppBarTitle`]
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct TopAppBarTitleProps {
     pub children: Children,
 }
@@ -14,30 +14,19 @@ pub struct TopAppBarTitleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTopAppBarTitle {
-    props: TopAppBarTitleProps,
-}
+pub struct MatTopAppBarTitle;
 
 impl Component for MatTopAppBarTitle {
     type Message = ();
     type Properties = TopAppBarTitleProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
+    fn create(_: &Context<Self>) -> Self {
+        Self
     }
 
-    fn update(&mut self, _msg: Self::Message) -> bool {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let children = self
-            .props
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let children = props
             .children
             .iter()
             .map(|child| {
@@ -48,9 +37,9 @@ impl Component for MatTopAppBarTitle {
                     }
                     _ => {
                         html! {
-                            <span slot=SLOT>
-                                { child }
-                            </span>
+                             <span slot={SLOT}>
+                                 {child}
+                             </span>
                         }
                     }
                 }
@@ -58,7 +47,7 @@ impl Component for MatTopAppBarTitle {
             .collect::<Html>();
 
         html! {
-            { children }
+             {children}
         }
     }
 }

--- a/material-yew/src/top_app_bar/title.rs
+++ b/material-yew/src/top_app_bar/title.rs
@@ -14,14 +14,14 @@ pub struct TopAppBarTitleProps {
 /// If the child passed is an element (a `VTag`), then it is modified to include
 /// the appropriate attributes. Otherwise, the child is wrapped in a `span`
 /// containing said attributes.
-pub struct MatTopAppBarTitle;
+pub struct MatTopAppBarTitle {}
 
 impl Component for MatTopAppBarTitle {
     type Message = ();
     type Properties = TopAppBarTitleProps;
 
     fn create(_: &Context<Self>) -> Self {
-        Self
+        Self {}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/material-yew/src/top_app_bar_fixed.rs
+++ b/material-yew/src/top_app_bar_fixed.rs
@@ -23,7 +23,6 @@ loader_hack!(TopAppBarFixed);
 ///
 /// [MWC Documentation](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar-fixed)
 pub struct MatTopAppBarFixed {
-    props: TopAppBarFixedProps,
     node_ref: NodeRef,
     nav_listener: Option<EventListener>,
 }
@@ -34,7 +33,7 @@ pub struct MatTopAppBarFixed {
 ///
 /// - [Properties](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar-fixed#propertiesattributes)
 /// - [Events](https://github.com/material-components/material-components-web-components/tree/master/packages/top-app-bar-fixed#events)
-#[derive(Debug, Properties, Clone)]
+#[derive(Debug, Properties, PartialEq, Clone)]
 pub struct TopAppBarFixedProps {
     pub children: Children,
     #[prop_or_default]
@@ -54,38 +53,30 @@ impl Component for MatTopAppBarFixed {
     type Message = ();
     type Properties = TopAppBarFixedProps;
 
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         TopAppBarFixed::ensure_loaded();
         Self {
-            props,
             node_ref: NodeRef::default(),
             nav_listener: None,
         }
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
         html! {
-            <mwc-top-app-bar-fixed
-                centerTitle=bool_to_option(self.props.center_title)
-                dense=bool_to_option(self.props.dense)
-                prominent=bool_to_option(self.props.prominent)
-                ref=self.node_ref.clone()
-            >{ self.props.children.clone() }</mwc-top-app-bar-fixed>
+             <mwc-top-app-bar-fixed
+                 centerTitle={bool_to_option(props.center_title)}
+                 dense={bool_to_option(props.dense)}
+                 prominent={bool_to_option(props.prominent)}
+                 ref={self.node_ref.clone()}
+             >{props.children.clone()}</mwc-top-app-bar-fixed>
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        let props = ctx.props();
         if self.nav_listener.is_none() {
-            let callback = self.props.onnavigationiconclick.clone();
+            let callback = props.onnavigationiconclick.clone();
             let element = self.node_ref.cast::<Element>().unwrap();
 
             self.nav_listener = Some(EventListener::new(

--- a/material-yew/src/utils/weak_component_link.rs
+++ b/material-yew/src/utils/weak_component_link.rs
@@ -1,9 +1,10 @@
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
-use yew::html::{Component, ComponentLink};
+use yew::html::Component;
+use yew::html::Scope;
 
-pub struct WeakComponentLink<COMP: Component>(Rc<RefCell<Option<ComponentLink<COMP>>>>);
+pub struct WeakComponentLink<COMP: Component>(Rc<RefCell<Option<Scope<COMP>>>>);
 
 impl<COMP: Component> Clone for WeakComponentLink<COMP> {
     fn clone(&self) -> Self {
@@ -18,7 +19,7 @@ impl<COMP: Component> Default for WeakComponentLink<COMP> {
 }
 
 impl<COMP: Component> Deref for WeakComponentLink<COMP> {
-    type Target = Rc<RefCell<Option<ComponentLink<COMP>>>>;
+    type Target = Rc<RefCell<Option<Scope<COMP>>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/screenshots/Cargo.toml
+++ b/screenshots/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen = "0.2"
-yew = "0.18"
-yew-router = "0.15"
+yew = "0.19"
+yew-router = "0.16"
 material-yew = { path = "../material-yew", features = ["full"] }
 weblog = "0.3"

--- a/screenshots/src/main.rs
+++ b/screenshots/src/main.rs
@@ -170,14 +170,14 @@ impl Component for App {
         </>};
 
         html! { <>
-        <main id="screenshots">
-            <MatSelect label="Components" outlined=true onselected={on_selected} >
-                { for COMPONENTS.iter().map(list_item)}
-            </MatSelect>
-            <BrowserRouter>
+        <BrowserRouter>
+            <main id="screenshots">
+                <MatSelect label="Components" outlined=true onselected={on_selected} >
+                    { for COMPONENTS.iter().map(list_item)}
+                </MatSelect>
                 <Switch<AppRoute> render={Switch::render(move |switch| Self::switch(*switch, menu.clone()))} />
-            </BrowserRouter>
-        </main>
+            </main>
+        </BrowserRouter>
         </>}
     }
 }

--- a/screenshots/src/main.rs
+++ b/screenshots/src/main.rs
@@ -9,6 +9,7 @@ use material_yew::{
     WeakComponentLink,
 };
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 use yew_router::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Routable)]
@@ -367,11 +368,11 @@ impl App {
                 html! {
                      <MatDialog open=true>
                          {"Delete item?"}
-                         <MatDialogAction action_type={ActionType::Primary} action={String::from("ok")}>
+                         <MatDialogAction action_type={ActionType::Primary} action={AttrValue::from("ok")}>
                              <MatButton label="Yes" />
                          </MatDialogAction>
 
-                         <MatDialogAction action_type={ActionType::Secondary} action={String::from("cancel")}>
+                         <MatDialogAction action_type={ActionType::Secondary} action={AttrValue::from("cancel")}>
                              <MatButton label="No" />
                          </MatDialogAction>
                      </MatDialog>

--- a/screenshots/src/main.rs
+++ b/screenshots/src/main.rs
@@ -8,52 +8,50 @@ use material_yew::{
     MatSelect, MatSlider, MatSnackbar, MatSwitch, MatTab, MatTabBar, MatTextArea, MatTextField,
     WeakComponentLink,
 };
-use std::borrow::Cow;
 use yew::prelude::*;
-use yew_router::agent::RouteRequest;
 use yew_router::prelude::*;
 
-#[derive(Switch, Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Routable)]
 pub enum AppRoute {
-    #[to = "/button"]
+    #[at("/button")]
     Button,
-    #[to = "/checkbox"]
+    #[at("/checkbox")]
     Checkbox,
-    #[to = "/radio"]
+    #[at("/radio")]
     Radio,
-    #[to = "/switch"]
+    #[at("/switch")]
     Switch,
-    #[to = "/fab"]
+    #[at("/fab")]
     Fab,
-    #[to = "/icon-button-toggle"]
+    #[at("/icon-button-toggle")]
     IconButtonToggle,
-    #[to = "/icon-button"]
+    #[at("/icon-button")]
     IconButton,
-    #[to = "/icon"]
+    #[at("/icon")]
     Icon,
-    #[to = "/circular-progress"]
+    #[at("/circular-progress")]
     CircularProgress,
-    #[to = "/form-field"]
+    #[at("/form-field")]
     FormField,
-    #[to = "/linear-progress"]
+    #[at("/linear-progress")]
     LinearProgress,
-    #[to = "/list"]
+    #[at("/list")]
     List,
-    #[to = "/slider"]
+    #[at("/slider")]
     Slider,
-    #[to = "/tabs"]
+    #[at("/tabs")]
     Tabs,
-    #[to = "/snackbar"]
+    #[at("/snackbar")]
     Snackbar,
-    #[to = "/textfield"]
+    #[at("/textfield")]
     Textfield,
-    #[to = "/textarea"]
+    #[at("/textarea")]
     TextArea,
-    #[to = "/select"]
+    #[at("/select")]
     Select,
-    #[to = "/menu"]
+    #[at("/menu")]
     Menu,
-    #[to = "/dialog"]
+    #[at("/dialog")]
     Dialog,
 }
 
@@ -110,11 +108,7 @@ const COMPONENTS: [AppRoute; 20] = [
     AppRoute::Dialog,
 ];
 
-type AppRouter = Router<AppRoute>;
-
 pub struct App {
-    link: ComponentLink<Self>,
-    router: RouteAgentDispatcher<()>,
     menu_link: WeakComponentLink<MatMenu>,
 }
 
@@ -127,15 +121,13 @@ impl Component for App {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
-            router: Default::default(),
             menu_link: Default::default(),
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Select(details) => {
                 let index = match details.index {
@@ -146,8 +138,7 @@ impl Component for App {
                     .get(index)
                     .expect("index too high. This should never happen")
                     .clone();
-                let route = Route::from(component);
-                self.router.send(RouteRequest::ChangeRoute(route));
+                use_history().unwrap().push(component);
                 true
             }
             Msg::OpenMenu => {
@@ -156,25 +147,22 @@ impl Component for App {
             }
         }
     }
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
 
-    fn view(&self) -> Html {
-        let on_selected = self.link.callback(Msg::Select);
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let on_selected = ctx.link().callback(Msg::Select);
         let list_item = |comp: &AppRoute| {
             html! {
-                <MatListItem value=format!("{:?}", comp)> { comp.to_string() } </MatListItem>
+                 <MatListItem value={format!("{:?}", comp)}> {comp.to_string()} </MatListItem>
             }
         };
 
         // this is a special case as its stateful
         let menu = html! { <>
-            <span onclick=self.link.callback(|_| Msg::OpenMenu) >
+            <span onclick={ctx.link().callback(|_| Msg::OpenMenu)} >
                 <MatButton label="Show meat" />
             </span>
             <div>
-                <MatMenu menu_link=self.menu_link.clone() open=true>
+                <MatMenu menu_link={self.menu_link.clone()} open=true>
                     <MatListItem>{"Chicken"}</MatListItem>
                     <MatListItem>{"Mutton"}</MatListItem>
                     <MatListItem>{"Beef"}</MatListItem>
@@ -184,12 +172,14 @@ impl Component for App {
 
         html! { <>
         <main id="screenshots">
-            <MatSelect label="Components" outlined=true onselected=on_selected >
-                { for COMPONENTS.iter().map(list_item) }
+            <MatSelect label="Components" outlined=true onselected={on_selected} >
+                { for COMPONENTS.iter().map(list_item)}
             </MatSelect>
-            <AppRouter render=AppRouter::render(move |switch| Self::switch(switch, menu.clone())) />
+            <BrowserRouter>
+                <Switch<AppRoute> render={Switch::render(move |switch| Self::switch(*switch, menu.clone()))} />
+            </BrowserRouter>
         </main>
-        </> }
+        </>}
     }
 }
 
@@ -198,194 +188,194 @@ impl App {
         let ret = match switch {
             AppRoute::Button => {
                 html! {
-                    <section id="button" class="grid">
-                        <MatButton label="Button" />
-                        <MatButton label="Button" outlined=true />
-                        <MatButton label="Button" raised=true />
-                        <MatButton label="Button" dense=true outlined=true />
-                    </section>
+                     <section id="button" class="grid">
+                         <MatButton label="Button" />
+                         <MatButton label="Button" outlined=true />
+                         <MatButton label="Button" raised=true />
+                         <MatButton label="Button" dense=true outlined=true />
+                     </section>
                 }
             }
             AppRoute::Checkbox => {
                 html! {
-                    <section id="checkbox" class="grid">
-                        <MatCheckbox />
-                        <MatCheckbox checked=true />
-                    </section>
+                     <section id="checkbox" class="grid">
+                         <MatCheckbox />
+                         <MatCheckbox checked=true />
+                     </section>
                 }
             }
             AppRoute::Radio => {
                 html! {
-                    <section id="radio" class="grid">
-                        <MatRadio />
-                        <MatRadio checked=true />
-                    </section>
+                     <section id="radio" class="grid">
+                         <MatRadio />
+                         <MatRadio checked=true />
+                     </section>
                 }
             }
             AppRoute::Switch => {
                 html! {
-                    <section id="switch" class="grid">
-                        <MatSwitch />
-                        <MatSwitch checked=true />
-                    </section>
+                     <section id="switch" class="grid">
+                         <MatSwitch />
+                         <MatSwitch checked=true />
+                     </section>
                 }
             }
             AppRoute::Fab => {
                 html! {
-                    <section id="fab" class="grid">
-                        <div>
-                            <MatFab icon="edit" />
-                            <MatFab icon="add" mini=true />
-                        </div>
-                        <MatFab icon="shopping_cart" label="Add to cart" extended=true />
-                    </section>
+                     <section id="fab" class="grid">
+                         <div>
+                             <MatFab icon="edit" />
+                             <MatFab icon="add" mini=true />
+                         </div>
+                         <MatFab icon="shopping_cart" label="Add to cart" extended=true />
+                     </section>
                 }
             }
             AppRoute::IconButton => {
                 html! {
-                    <section id="icon-button" class="grid">
-                        <MatIconButton icon="backup" />
-                        <MatIconButton icon="code" />
-                        <MatIconButton icon="cast" />
-                        <MatIconButton icon="favorite" />
-                    </section>
+                     <section id="icon-button" class="grid">
+                         <MatIconButton icon="backup" />
+                         <MatIconButton icon="code" />
+                         <MatIconButton icon="cast" />
+                         <MatIconButton icon="favorite" />
+                     </section>
                 }
             }
             AppRoute::Icon => {
                 html! {
-                    <section id="icon" class="grid">
-                        <MatIcon>{"backup"}</MatIcon>
-                        <MatIcon>{"code"}</MatIcon>
-                        <MatIcon>{"cast"}</MatIcon>
-                        <MatIcon>{"favorite"}</MatIcon>
-                    </section>
+                     <section id="icon" class="grid">
+                         <MatIcon>{"backup"}</MatIcon>
+                         <MatIcon>{"code"}</MatIcon>
+                         <MatIcon>{"cast"}</MatIcon>
+                         <MatIcon>{"favorite"}</MatIcon>
+                     </section>
                 }
             }
             AppRoute::CircularProgress => {
                 html! {
-                    <section id="circular-progress" class="grid">
-                        <MatCircularProgress progress=0.1 />
-                        <MatCircularProgress progress=0.2 />
-                        <MatCircularProgress progress=0.4 />
-                        <MatCircularProgress progress=0.6 />
-                        <MatCircularProgress progress=0.8 />
-                        <MatCircularProgress progress=1.0 />
-                    </section>
+                     <section id="circular-progress" class="grid">
+                         <MatCircularProgress progress=0.1 />
+                         <MatCircularProgress progress=0.2 />
+                         <MatCircularProgress progress=0.4 />
+                         <MatCircularProgress progress=0.6 />
+                         <MatCircularProgress progress=0.8 />
+                         <MatCircularProgress progress=1.0 />
+                     </section>
                 }
             }
             AppRoute::FormField => {
                 html! {
-                    <section id="form-field" class="container">
-                        <MatFormfield align_end=true>
-                            <MatTextField label="Password" field_type=TextFieldType::Password required=true />
-                        </MatFormfield>
-                    </section>
+                     <section id="form-field" class="container">
+                         <MatFormfield align_end=true>
+                             <MatTextField label="Password" field_type={TextFieldType::Password} required=true />
+                         </MatFormfield>
+                     </section>
                 }
             }
             AppRoute::LinearProgress => {
                 html! {
-                    <section id="linear-progress" class="grid">
-                        <MatLinearProgress progress=0.75 buffer=0.5 />
-                        <MatLinearProgress indeterminate=true />
-                    </section>
+                     <section id="linear-progress" class="grid">
+                         <MatLinearProgress progress=0.75 buffer=0.5 />
+                         <MatLinearProgress indeterminate=true />
+                     </section>
                 }
             }
             AppRoute::List => {
                 html! {
-                    <section id="list" class="container">
-                        <MatList>
-                            <MatListItem>{"Item 0"}</MatListItem>
-                            <MatListItem selected=true>{"Item 1"}</MatListItem>
-                            <MatListItem>{"Item 2"}</MatListItem>
-                        </MatList>
-                    </section>
+                     <section id="list" class="container">
+                         <MatList>
+                             <MatListItem>{"Item 0"}</MatListItem>
+                             <MatListItem selected=true>{"Item 1"}</MatListItem>
+                             <MatListItem>{"Item 2"}</MatListItem>
+                         </MatList>
+                     </section>
                 }
             }
             AppRoute::IconButtonToggle => {
                 html! {
-                    <section id="icon-button-toggle" class="grid">
-                        <MatIconButtonToggle on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" />
+                     <section id="icon-button-toggle" class="grid">
+                         <MatIconButtonToggle on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" />
 
-                        <MatIconButtonToggle>
-                            <MatOnIconButtonToggle>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
-                            </MatOnIconButtonToggle>
+                         <MatIconButtonToggle>
+                             <MatOnIconButtonToggle>
+                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
+                             </MatOnIconButtonToggle>
 
-                            <MatOffIconButtonToggle>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
-                            </MatOffIconButtonToggle>
-                        </MatIconButtonToggle>
-                    </section>
+                             <MatOffIconButtonToggle>
+                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
+                             </MatOffIconButtonToggle>
+                         </MatIconButtonToggle>
+                     </section>
                 }
             }
             AppRoute::Slider => {
                 html! {
-                    <section id="slider" class="grid">
-                        <MatSlider />
-                    </section>
+                     <section id="slider" class="grid">
+                         <MatSlider />
+                     </section>
                 }
             }
             AppRoute::Tabs => {
                 html! {
-                <section id="tabs" class="container">
-                    <MatTabBar>
-                        <MatTab label="one" />
-                        <MatTab label="two" />
-                        <MatTab label="three" />
-                    </MatTabBar>
-                </section>
+                 <section id="tabs" class="container">
+                     <MatTabBar>
+                         <MatTab label="one" />
+                         <MatTab label="two" />
+                         <MatTab label="three" />
+                     </MatTabBar>
+                 </section>
                 }
             }
             AppRoute::Snackbar => {
                 html! {
-                    <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." timeout_ms=-1 open=true />
+                     <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." timeout_ms={-1} open=true />
                 }
             }
             AppRoute::Textfield => {
                 html! {
-                    <section id="textfield" class="grid">
-                        <MatTextField label="Name" />
-                        <MatTextField label="Email" field_type=TextFieldType::Email outlined=true />
-                    </section>
+                     <section id="textfield" class="grid">
+                         <MatTextField label="Name" />
+                         <MatTextField label="Email" field_type={TextFieldType::Email} outlined=true />
+                     </section>
                 }
             }
             AppRoute::TextArea => {
                 html! {
-                    <section id="textarea" class="grid">
-                        <MatTextArea label="Thoughts?" />
-                        <MatTextArea label="Outlined Thoughts" outlined=true />
-                    </section>
+                     <section id="textarea" class="grid">
+                         <MatTextArea label="Thoughts?" />
+                         <MatTextArea label="Outlined Thoughts" outlined=true />
+                     </section>
                 }
             }
             AppRoute::Select => {
                 html! {
-                    <section id="select" class="container">
-                        <MatSelect label="Components" outlined=true>
-                            <MatListItem value="2"> { "Vegetables" } </MatListItem>
-                            <MatListItem value="3"> { "Meat" } </MatListItem>
-                        </MatSelect>
-                    </section>
+                     <section id="select" class="container">
+                         <MatSelect label="Components" outlined=true>
+                             <MatListItem value="2"> {"Vegetables"} </MatListItem>
+                             <MatListItem value="3"> {"Meat"} </MatListItem>
+                         </MatSelect>
+                     </section>
                 }
             }
             AppRoute::Menu => {
                 html! {
-                    <section id="menu" class="container">
-                        {menu}
-                    </section>
+                     <section id="menu" class="container">
+                         {menu}
+                     </section>
                 }
             }
             AppRoute::Dialog => {
                 html! {
-                    <MatDialog open=true>
-                        {"Delete item?"}
-                        <MatDialogAction action_type=ActionType::Primary action=Cow::from("ok")>
-                            <MatButton label="Yes" />
-                        </MatDialogAction>
+                     <MatDialog open=true>
+                         {"Delete item?"}
+                         <MatDialogAction action_type={ActionType::Primary} action={String::from("ok")}>
+                             <MatButton label="Yes" />
+                         </MatDialogAction>
 
-                        <MatDialogAction action_type=ActionType::Secondary action=Cow::from("cancel")>
-                            <MatButton label="No" />
-                        </MatDialogAction>
-                    </MatDialog>
+                         <MatDialogAction action_type={ActionType::Secondary} action={String::from("cancel")}>
+                             <MatButton label="No" />
+                         </MatDialogAction>
+                     </MatDialog>
                 }
             }
         };
@@ -394,5 +384,5 @@ impl App {
 }
 
 fn main() {
-    yew::start_app::<App>()
+    yew::start_app::<App>();
 }

--- a/screenshots/src/main.rs
+++ b/screenshots/src/main.rs
@@ -134,10 +134,9 @@ impl Component for App {
                     ListIndex::Single(Some(index)) => index,
                     _ => panic!("Unreachable executed"),
                 };
-                let component = COMPONENTS
+                let component = *COMPONENTS
                     .get(index)
-                    .expect("index too high. This should never happen")
-                    .clone();
+                    .expect("index too high. This should never happen");
                 use_history().unwrap().push(component);
                 true
             }

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -8,8 +8,10 @@ build = "build.rs"
 
 [dependencies]
 wasm-bindgen = "0.2"
-yew = "0.18"
-yew-router = "0.15"
+yew = "0.19"
+yew-router = "0.16"
+gloo-utils = "0.1"
+gloo-console = "0.2"
 
 material-yew = { path = "../material-yew", features = ["full"] }
 web-sys = { version = "0.3", features = ["HtmlMetaElement", "Document", "Element", "DocumentFragment", "HtmlTemplateElement", "MediaQueryList"] }

--- a/website/build.rs
+++ b/website/build.rs
@@ -60,7 +60,7 @@ fn main() {
                         "syntect-dumps/Material-Theme-Lighter.theme"
                     ));
                     let html =
-                        highlighted_html_for_string(&to_highlight, &syntax_set, &syntax, &theme);
+                        highlighted_html_for_string(&to_highlight, &syntax_set, syntax, &theme);
                     // And put it into the vector
                     new_parser.push(Event::Html(CowStr::from(html)));
                     to_highlight = String::new();

--- a/website/src/components/button.rs
+++ b/website/src/components/button.rs
@@ -2,6 +2,7 @@ use crate::components::Codeblock;
 use crate::with_raw_code;
 use material_yew::MatButton;
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 pub struct Button {}
 
@@ -17,55 +18,55 @@ impl Component for Button {
         let standard_button = with_raw_code!(standard_button { html! {
          <section class="demo">
              <MatButton label="Click me!" />
-             <MatButton label="Click me!" icon={String::from("code")} />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} />
          </section>
         }});
 
         let outlined_button = with_raw_code!(outlined_button { html! {
          <section class="demo">
              <MatButton label="Click me!" outlined=true />
-             <MatButton label="Click me!" icon={String::from("code")} outlined=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} outlined=true />
          </section>
         }});
 
         let raised_button = with_raw_code!(raised_button { html! {
          <section class="demo">
              <MatButton label="Click me!" raised=true/>
-             <MatButton label="Click me!" icon={String::from("code")} raised=true/>
+             <MatButton label="Click me!" icon={AttrValue::from("code")} raised=true/>
          </section>
         }});
 
         let unelevated_button = with_raw_code!(unelevated_button { html! {
          <section class="demo">
              <MatButton label="Click me!" unelevated=true />
-             <MatButton label="Click me!" icon={String::from("code")} unelevated=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} unelevated=true />
          </section>
         }});
 
         let dense_button = with_raw_code!(dense_button { html! {
          <section class="demo">
                  <MatButton label="Click me!" dense=true />
-                 <MatButton label="Click me!" icon={String::from("code")} dense=true />
+                 <MatButton label="Click me!" icon={AttrValue::from("code")} dense=true />
              </section>
         }});
 
         let trailing_icon_button = with_raw_code!(trailing_icon_button { html! {
          <section class="demo">
-             <MatButton label="Click me!" icon={String::from("code")} trailing_icon=true />
-             <MatButton label="Click me!" icon={String::from("code")} outlined=true trailing_icon=true />
-             <MatButton label="Click me!" icon={String::from("code")} raised=true trailing_icon=true />
-             <MatButton label="Click me!" icon={String::from("code")} unelevated=true trailing_icon=true />
-             <MatButton label="Click me!" icon={String::from("code")} dense=true trailing_icon=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} trailing_icon=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} outlined=true trailing_icon=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} raised=true trailing_icon=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} unelevated=true trailing_icon=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} dense=true trailing_icon=true />
          </section>
         }});
 
         let disabled_button = with_raw_code!(disabled_button { html! {
          <section class="demo">
-             <MatButton label="Click me!" icon={String::from("code")} disabled=true />
-             <MatButton label="Click me!" icon={String::from("code")} outlined=true disabled=true />
-             <MatButton label="Click me!" icon={String::from("code")} raised=true disabled=true />
-             <MatButton label="Click me!" icon={String::from("code")} unelevated=true disabled=true />
-             <MatButton label="Click me!" icon={String::from("code")} dense=true disabled=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} disabled=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} outlined=true disabled=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} raised=true disabled=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} unelevated=true disabled=true />
+             <MatButton label="Click me!" icon={AttrValue::from("code")} dense=true disabled=true />
          </section>
         }});
 

--- a/website/src/components/button.rs
+++ b/website/src/components/button.rs
@@ -1,7 +1,6 @@
 use crate::components::Codeblock;
 use crate::with_raw_code;
 use material_yew::MatButton;
-use std::borrow::Cow;
 use yew::prelude::*;
 
 pub struct Button {}
@@ -10,89 +9,81 @@ impl Component for Button {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard_button = with_raw_code!(standard_button { html! {
-        <section class="demo">
-            <MatButton label="Click me!" />
-            <MatButton label="Click me!" icon=Cow::from("code") />
-        </section>
+         <section class="demo">
+             <MatButton label="Click me!" />
+             <MatButton label="Click me!" icon={String::from("code")} />
+         </section>
         }});
 
         let outlined_button = with_raw_code!(outlined_button { html! {
-        <section class="demo">
-            <MatButton label="Click me!" outlined=true />
-            <MatButton label="Click me!" icon=Cow::from("code") outlined=true />
-        </section>
+         <section class="demo">
+             <MatButton label="Click me!" outlined=true />
+             <MatButton label="Click me!" icon={String::from("code")} outlined=true />
+         </section>
         }});
 
         let raised_button = with_raw_code!(raised_button { html! {
-        <section class="demo">
-            <MatButton label="Click me!" raised=true/>
-            <MatButton label="Click me!" icon=Cow::from("code") raised=true/>
-        </section>
+         <section class="demo">
+             <MatButton label="Click me!" raised=true/>
+             <MatButton label="Click me!" icon={String::from("code")} raised=true/>
+         </section>
         }});
 
         let unelevated_button = with_raw_code!(unelevated_button { html! {
-        <section class="demo">
-            <MatButton label="Click me!" unelevated=true />
-            <MatButton label="Click me!" icon=Cow::from("code") unelevated=true />
-        </section>
+         <section class="demo">
+             <MatButton label="Click me!" unelevated=true />
+             <MatButton label="Click me!" icon={String::from("code")} unelevated=true />
+         </section>
         }});
 
         let dense_button = with_raw_code!(dense_button { html! {
-        <section class="demo">
-                <MatButton label="Click me!" dense=true />
-                <MatButton label="Click me!" icon=Cow::from("code") dense=true />
-            </section>
+         <section class="demo">
+                 <MatButton label="Click me!" dense=true />
+                 <MatButton label="Click me!" icon={String::from("code")} dense=true />
+             </section>
         }});
 
         let trailing_icon_button = with_raw_code!(trailing_icon_button { html! {
-        <section class="demo">
-            <MatButton label="Click me!" icon=Cow::from("code") trailing_icon=true />
-            <MatButton label="Click me!" icon=Cow::from("code") outlined=true trailing_icon=true />
-            <MatButton label="Click me!" icon=Cow::from("code") raised=true trailing_icon=true />
-            <MatButton label="Click me!" icon=Cow::from("code") unelevated=true trailing_icon=true />
-            <MatButton label="Click me!" icon=Cow::from("code") dense=true trailing_icon=true />
-        </section>
+         <section class="demo">
+             <MatButton label="Click me!" icon={String::from("code")} trailing_icon=true />
+             <MatButton label="Click me!" icon={String::from("code")} outlined=true trailing_icon=true />
+             <MatButton label="Click me!" icon={String::from("code")} raised=true trailing_icon=true />
+             <MatButton label="Click me!" icon={String::from("code")} unelevated=true trailing_icon=true />
+             <MatButton label="Click me!" icon={String::from("code")} dense=true trailing_icon=true />
+         </section>
         }});
 
         let disabled_button = with_raw_code!(disabled_button { html! {
-        <section class="demo">
-            <MatButton label="Click me!" icon=Cow::from("code") disabled=true />
-            <MatButton label="Click me!" icon=Cow::from("code") outlined=true disabled=true />
-            <MatButton label="Click me!" icon=Cow::from("code") raised=true disabled=true />
-            <MatButton label="Click me!" icon=Cow::from("code") unelevated=true disabled=true />
-            <MatButton label="Click me!" icon=Cow::from("code") dense=true disabled=true />
-        </section>
+         <section class="demo">
+             <MatButton label="Click me!" icon={String::from("code")} disabled=true />
+             <MatButton label="Click me!" icon={String::from("code")} outlined=true disabled=true />
+             <MatButton label="Click me!" icon={String::from("code")} raised=true disabled=true />
+             <MatButton label="Click me!" icon={String::from("code")} unelevated=true disabled=true />
+             <MatButton label="Click me!" icon={String::from("code")} dense=true disabled=true />
+         </section>
         }});
 
         html! {<>
 
-            <Codeblock title="Standard" code_and_html=standard_button />
+            <Codeblock title="Standard" code_and_html={standard_button} />
 
-            <Codeblock title="Outlined" code_and_html=outlined_button />
+            <Codeblock title="Outlined" code_and_html={outlined_button} />
 
-            <Codeblock title="Raised" code_and_html=raised_button />
+            <Codeblock title="Raised" code_and_html={raised_button} />
 
-            <Codeblock title="Unelevated" code_and_html=unelevated_button />
+            <Codeblock title="Unelevated" code_and_html={unelevated_button} />
 
-            <Codeblock title="Dense" code_and_html=dense_button />
+            <Codeblock title="Dense" code_and_html={dense_button} />
 
-            <Codeblock title="Trailing icon" code_and_html=trailing_icon_button />
+            <Codeblock title="Trailing icon" code_and_html={trailing_icon_button} />
 
-            <Codeblock title="Disabled" code_and_html=disabled_button />
+            <Codeblock title="Disabled" code_and_html={disabled_button} />
 
         </>}
     }

--- a/website/src/components/checkbox.rs
+++ b/website/src/components/checkbox.rs
@@ -9,56 +9,48 @@ impl Component for Checkbox {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard_checkbox = with_raw_code!(standard_checkbox { html! {
-        <section class="demo">
-            <MatCheckbox />
-            <h3>{"Standard checkbox"}</h3>
-        </section>
+         <section class="demo">
+             <MatCheckbox />
+             <h3>{"Standard checkbox"}</h3>
+         </section>
         }});
 
         let checked_checkbox = with_raw_code!(checked_checkbox { html! {
-        <section class="demo">
-            <MatCheckbox checked=true />
-            <h3>{"Checked checkbox"}</h3>
-        </section>
+         <section class="demo">
+             <MatCheckbox checked=true />
+             <h3>{"Checked checkbox"}</h3>
+         </section>
         }});
 
         let indeterminate_checkbox = with_raw_code!(indeterminate_checkbox { html! {
-        <section class="demo">
-            <MatCheckbox indeterminate=true />
-            <h3>{"Indeterminate checkbox"}</h3>
-        </section>
+         <section class="demo">
+             <MatCheckbox indeterminate=true />
+             <h3>{"Indeterminate checkbox"}</h3>
+         </section>
         }});
 
         let disabled_checkbox = with_raw_code!(disabled_checkbox { html! {
-        <section class="demo">
-            <MatCheckbox disabled=true />
-            <h3>{"Disabled checkbox"}</h3>
-        </section>
+         <section class="demo">
+             <MatCheckbox disabled=true />
+             <h3>{"Disabled checkbox"}</h3>
+         </section>
         }});
 
         html! {<>
 
-            <Codeblock title="Standard" code_and_html=standard_checkbox />
+            <Codeblock title="Standard" code_and_html={standard_checkbox} />
 
-            <Codeblock title="Checked" code_and_html=checked_checkbox />
+            <Codeblock title="Checked" code_and_html={checked_checkbox} />
 
-            <Codeblock title="Indeterminate" code_and_html=indeterminate_checkbox />
+            <Codeblock title="Indeterminate" code_and_html={indeterminate_checkbox} />
 
-            <Codeblock title="Disabled" code_and_html=disabled_checkbox />
+            <Codeblock title="Disabled" code_and_html={disabled_checkbox} />
 
         </>}
     }

--- a/website/src/components/circular_progress.rs
+++ b/website/src/components/circular_progress.rs
@@ -4,7 +4,6 @@ use material_yew::{MatButton, MatCircularProgress, MatCircularProgressFourColor}
 use yew::prelude::*;
 
 pub struct CircularProgress {
-    link: ComponentLink<Self>,
     closed: bool,
     progress: f32,
 }
@@ -18,71 +17,66 @@ impl Component for CircularProgress {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
             closed: false,
-            link,
             progress: 0.0,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ChangeProgress => {
                 self.progress += 0.1;
             }
             Msg::Close => {
-                yew::services::ConsoleService::log("test");
                 self.closed = !self.closed;
             }
         }
         true
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let toggle_example = with_raw_code!(toggle_example { html! {
-            <section class="demo">
-                <span onclick=self.link.callback(|_| Msg::Close)>
-                    <MatButton label="Toggle" raised=true  />
-                 </span><br />
-                <MatCircularProgress closed=self.closed progress=0.75 />
-            </section>
+             <section class="demo">
+                 <span onclick={link.callback(|_| Msg::Close)} >
+                     <MatButton label="Toggle" raised=true  />
+                  </span><br />
+                 <MatCircularProgress closed={self.closed} progress=0.75 />
+             </section>
         }});
 
         let indeterminate_ex = with_raw_code!(indeterminate_ex { html! {
-            <MatCircularProgress indeterminate=true />
+             <MatCircularProgress indeterminate=true />
         }});
 
         let determinate_ex = with_raw_code!(determinate_ex { html! {
-            <section class="demo">
-                <span onclick=self.link.callback(|_| Msg::ChangeProgress)>
-                    <MatButton label="Increase progress" raised=true />
-                </span>
-                <MatCircularProgress progress=self.progress />
-            </section>
+             <section class="demo">
+                 <span onclick={link.callback(|_| Msg::ChangeProgress)} >
+                     <MatButton label="Increase progress" raised=true />
+                 </span>
+                 <MatCircularProgress progress={self.progress} />
+             </section>
         }});
 
         let four_color_ex = with_raw_code!(four_color_ex { html! {
-            <MatCircularProgressFourColor indeterminate=true />
+             <MatCircularProgressFourColor indeterminate=true />
         }});
 
         html! {<>
-            <Codeblock code_and_html=toggle_example title="Toggle open state" />
+            <Codeblock code_and_html={toggle_example} title="Toggle open state" />
 
-            <Codeblock code_and_html=indeterminate_ex title="Indeterminate" />
+            <Codeblock code_and_html={indeterminate_ex} title="Indeterminate" />
 
-            <Codeblock code_and_html=determinate_ex title="Determinate" />
+            <Codeblock code_and_html={determinate_ex} title="Determinate" />
 
             <p>
                 <b>{"Note:"}</b> {" Four colored variants of circular progress is available under "} <code>{"MatCircularProgressFourColor"}</code>
             </p>
 
             <section class="four-colored-progress">
-                <Codeblock code_and_html=four_color_ex title="Four colored indeterminate" />
+                <Codeblock code_and_html={four_color_ex} title="Four colored indeterminate" />
             </section>
         </>}
     }

--- a/website/src/components/code_block.rs
+++ b/website/src/components/code_block.rs
@@ -3,8 +3,6 @@ use material_yew::MatIconButton;
 use yew::prelude::*;
 
 pub struct Codeblock {
-    link: ComponentLink<Self>,
-    props: Props,
     showing_code: bool,
 }
 
@@ -12,7 +10,7 @@ pub enum Msg {
     FlipShowCode,
 }
 
-#[derive(Properties, Clone)]
+#[derive(Properties, PartialEq, Clone)]
 pub struct Props {
     // pub children: Children,
     // pub code: String,
@@ -26,15 +24,13 @@ impl Component for Codeblock {
     type Message = Msg;
     type Properties = Props;
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
-            props,
             showing_code: false,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::FlipShowCode => {
                 self.showing_code = !self.showing_code;
@@ -43,18 +39,15 @@ impl Component for Codeblock {
         }
     }
 
-    fn change(&mut self, props: Self::Properties) -> bool {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let code = html_to_element(&self.props.code_and_html.0);
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+        let link = ctx.link();
+        let code = html_to_element(&props.code_and_html.0);
         html! { <>
-            <section class="codeblock" style=format!("max-width: {}%", self.props.max_width)>
+            <section class="codeblock" style={format!("max-width: {}%", props.max_width)}>
                 <section class="header">
-                    <h2 class="title">{&self.props.title}</h2>
-                    <span class="right-icon" onclick=self.link.callback(|_| Msg::FlipShowCode)>
+                    <h2 class="title">{&props.title}</h2>
+                    <span class="right-icon" onclick={link.callback(|_| Msg::FlipShowCode)}>
                         <MatIconButton icon="code" />
                     </span>
                 </section>
@@ -62,11 +55,11 @@ impl Component for Codeblock {
                 {
                     if self.showing_code {
                         {code}
-                    } else { html!{} }
-                }
+                   } else { html!{}}
+               }
 
-                { self.props.code_and_html.1.clone() }
+                {props.code_and_html.1.clone()}
             </section>
-        </> }
+        </>}
     }
 }

--- a/website/src/components/components_list.rs
+++ b/website/src/components/components_list.rs
@@ -1,4 +1,4 @@
-use crate::{AppRoute, AppRouterAnchor};
+use crate::{AppLink, AppRoute};
 use yew::prelude::*;
 
 pub struct Components {}
@@ -7,53 +7,45 @@ impl Component for Components {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let component_card = |name: &str, route| {
             let path = join("-", name.split(' ')).to_lowercase();
 
             html! {
-                <AppRouterAnchor route=route>
-                    <img src=format!("/assets/{}.png", path) />
-                    <h6>{ name }</h6>
-                </AppRouterAnchor>
+                 <AppLink to={route}>
+                     <img src={format!("/assets/{}.png", path)} />
+                     <h6>{name}</h6>
+                 </AppLink>
             }
         };
         html! {
-         <section class="components-grid">
-             { component_card("Button", AppRoute::Button) }
-             { component_card("Checkbox", AppRoute::Checkbox) }
-             { component_card("Radio", AppRoute::Radio) }
-             { component_card("Switch", AppRoute::Switch) }
-             { component_card("Floating Action Button", AppRoute::Fab) }
-             { component_card("Icon Button", AppRoute::IconButton) }
-             { component_card("Icon", AppRoute::Icon) }
-             { component_card("Circular Progress", AppRoute::CircularProgress) }
-             { component_card("Dialog", AppRoute::Dialog) }
-             // TODO { component_card("Drawer", AppRoute::Drawer) }
-             { component_card("Formfield", AppRoute::FormField) }
-             { component_card("Linear Progress", AppRoute::LinearProgress) }
-             { component_card("List", AppRoute::List) }
-             { component_card("Icon Button Toggle", AppRoute::IconButtonToggle) }
-             { component_card("Slider", AppRoute::Slider) }
-             { component_card("Tabs", AppRoute::Tabs) }
-             { component_card("Snackbar", AppRoute::Snackbar) }
-             { component_card("TextField", AppRoute::Textfield) }
-             { component_card("TextArea", AppRoute::TextArea) }
-             { component_card("Select", AppRoute::Select) }
-             { component_card("Menu", AppRoute::Menu) }
-         </section>
+          <section class="components-grid">
+              {component_card("Button", AppRoute::Button)}
+              {component_card("Checkbox", AppRoute::Checkbox)}
+              {component_card("Radio", AppRoute::Radio)}
+              {component_card("Switch", AppRoute::Switch)}
+              {component_card("Floating Action Button", AppRoute::Fab)}
+              {component_card("Icon Button", AppRoute::IconButton)}
+              {component_card("Icon", AppRoute::Icon)}
+              {component_card("Circular Progress", AppRoute::CircularProgress)}
+              {component_card("Dialog", AppRoute::Dialog)}
+              // TODO { component_card("Drawer", AppRoute::Drawer)}
+              {component_card("Formfield", AppRoute::FormField)}
+              {component_card("Linear Progress", AppRoute::LinearProgress)}
+              {component_card("List", AppRoute::List)}
+              {component_card("Icon Button Toggle", AppRoute::IconButtonToggle)}
+              {component_card("Slider", AppRoute::Slider)}
+              {component_card("Tabs", AppRoute::Tabs)}
+              {component_card("Snackbar", AppRoute::Snackbar)}
+              {component_card("TextField", AppRoute::Textfield)}
+              {component_card("TextArea", AppRoute::TextArea)}
+              {component_card("Select", AppRoute::Select)}
+              {component_card("Menu", AppRoute::Menu)}
+          </section>
         }
     }
 }

--- a/website/src/components/components_list.rs
+++ b/website/src/components/components_list.rs
@@ -60,6 +60,6 @@ where
         out.push_str(it.into());
         out.push_str(separator);
     });
-    let out = out.strip_suffix("-");
+    let out = out.strip_suffix('-');
     out.unwrap().to_owned()
 }

--- a/website/src/components/dialog.rs
+++ b/website/src/components/dialog.rs
@@ -5,6 +5,7 @@ use material_yew::{
     MatButton, MatDialog, WeakComponentLink,
 };
 use yew::prelude::*;
+use yew::virtual_dom::AttrValue;
 
 pub struct Dialog {
     basic_dialog_link: WeakComponentLink<MatDialog>,
@@ -75,14 +76,14 @@ impl Component for Dialog {
              <span onclick={link.callback(|_| Msg::ShowBasicDialog)}>
                  <MatButton raised=true label="Basic" />
              </span>
-             <MatDialog heading={String::from("Dialog header")} dialog_link={self.basic_dialog_link.clone()}
+             <MatDialog heading={AttrValue::from("Dialog header")} dialog_link={self.basic_dialog_link.clone()}
                  onclosing={Callback::from(|action| gloo_console::log!(&format!("onclosing action: {}", action)))}
                  onclosed={Callback::from(|action| gloo_console::log!(&format!("closed action: {}", action)))}>
                  {"Dialog body text"}
-                 <MatDialogAction action_type={ActionType::Primary} action={String::from("ok")}>
+                 <MatDialogAction action_type={ActionType::Primary} action={AttrValue::from("ok")}>
                      <MatButton label="Action 2" />
                  </MatDialogAction>
-                 <MatDialogAction action_type={ActionType::Secondary} action={String::from("cancel")}>
+                 <MatDialogAction action_type={ActionType::Secondary} action={AttrValue::from("cancel")}>
                      <MatButton label="Action 1" />
                  </MatDialogAction>
              </MatDialog>
@@ -94,7 +95,7 @@ impl Component for Dialog {
              <span onclick={link.callback(|_| Msg::ShowActionDialog)}>
                  <MatButton raised=true label="Actions" />
              </span>
-             <MatDialog heading={String::from("Actions")} dialog_link={self.action_dialog_link.clone()} >
+             <MatDialog heading={AttrValue::from("Actions")} dialog_link={self.action_dialog_link.clone()} >
                  {"
                     By setting the dialog_action=\"my-action\" attribute on any element projected
                     into MatDialog, you can close the dialog by clicking on that element. The
@@ -102,7 +103,7 @@ impl Component for Dialog {
                     \"closed\" event with an event detail of {action: \"my-action\"}
                 "}
 
-                 <MatDialogAction action_type={ActionType::Primary} action={String::from("customAction")}>
+                 <MatDialogAction action_type={ActionType::Primary} action={AttrValue::from("customAction")}>
                      <MatButton label="This has action" />
                  </MatDialogAction>
                  <MatDialogAction action_type={ActionType::Secondary}>
@@ -120,9 +121,9 @@ impl Component for Dialog {
              <span onclick={link.callback(|_| Msg::ShowScrollableDialog)}>
                  <MatButton raised=true label="Scrollable" />
              </span>
-             <MatDialog heading={String::from("Scrollable")} dialog_link={self.scrollable_dialog_link.clone()}>
+             <MatDialog heading={AttrValue::from("Scrollable")} dialog_link={self.scrollable_dialog_link.clone()}>
                  {text}
-                 <MatDialogAction action_type={ActionType::Primary} action={String::from("close")}>
+                 <MatDialogAction action_type={ActionType::Primary} action={AttrValue::from("close")}>
                      <MatButton label="Close this!" />
                  </MatDialogAction>
              </MatDialog>
@@ -134,7 +135,7 @@ impl Component for Dialog {
              <span onclick={link.callback(|_| Msg::ShowHideActionDialog)}>
                  <MatButton raised=true label="Hide Actions" />
              </span>
-             <MatDialog heading={String::from("Hide Actions")} dialog_link={self.hide_action_dialog_link.clone()} hide_action={self.hide_actions}>
+             <MatDialog heading={AttrValue::from("Hide Actions")} dialog_link={self.hide_action_dialog_link.clone()} hide_action={self.hide_actions}>
                  <p>{"
                     If you don't have actions, you may want to set the \"hideActions\" property.
                     This property will remove extra whitespace at the bottom of this dialog.
@@ -153,15 +154,15 @@ impl Component for Dialog {
              <span onclick={link.callback(|_| Msg::ShowStackedDialog)}>
                  <MatButton raised=true label="Stacked" />
              </span>
-             <MatDialog heading={String::from("Stacked")} dialog_link={self.stacked_dialog_link.clone()} stacked=true>
+             <MatDialog heading={AttrValue::from("Stacked")} dialog_link={self.stacked_dialog_link.clone()} stacked=true>
                  {"
                     This is what happens when you set the stacked property on mwc-dialog.
                     Notice that the primary action is now on top.
                 "}
-                 <MatDialogAction action_type={ActionType::Primary} action={String::from("close")}>
+                 <MatDialogAction action_type={ActionType::Primary} action={AttrValue::from("close")}>
                      <MatButton label="Primary" />
                  </MatDialogAction>
-                 <MatDialogAction action_type={ActionType::Secondary} action={String::from("close")}>
+                 <MatDialogAction action_type={ActionType::Secondary} action={AttrValue::from("close")}>
                      <MatButton label="Secondary" />
                  </MatDialogAction>
              </MatDialog>

--- a/website/src/components/dialog.rs
+++ b/website/src/components/dialog.rs
@@ -4,12 +4,9 @@ use material_yew::{
     dialog::{ActionType, MatDialogAction},
     MatButton, MatDialog, WeakComponentLink,
 };
-use std::borrow::Cow;
 use yew::prelude::*;
-use yew::services::ConsoleService;
 
 pub struct Dialog {
-    link: ComponentLink<Self>,
     basic_dialog_link: WeakComponentLink<MatDialog>,
     action_dialog_link: WeakComponentLink<MatDialog>,
     scrollable_dialog_link: WeakComponentLink<MatDialog>,
@@ -31,9 +28,8 @@ impl Component for Dialog {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             basic_dialog_link: Default::default(),
             action_dialog_link: Default::default(),
             scrollable_dialog_link: Default::default(),
@@ -43,7 +39,7 @@ impl Component for Dialog {
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ShowBasicDialog => {
                 self.basic_dialog_link.show();
@@ -72,129 +68,126 @@ impl Component for Dialog {
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let basic = with_raw_code!(basic { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::ShowBasicDialog)>
-                <MatButton raised=true label="Basic" />
-            </span>
-            <MatDialog heading=Cow::from("Dialog header") dialog_link=self.basic_dialog_link.clone()
-                onclosing=Callback::from(|action| ConsoleService::log(&format!("onclosing action: {}", action)))
-                onclosed=Callback::from(|action| ConsoleService::log(&format!("closed action: {}", action)))>
-                {"Dialog body text"}
-                <MatDialogAction action_type=ActionType::Primary action=Cow::from("ok")>
-                    <MatButton label="Action 2" />
-                </MatDialogAction>
-                <MatDialogAction action_type=ActionType::Secondary action=Cow::from("cancel")>
-                    <MatButton label="Action 1" />
-                </MatDialogAction>
-            </MatDialog>
-        </section>
+         <section>
+             <span onclick={link.callback(|_| Msg::ShowBasicDialog)}>
+                 <MatButton raised=true label="Basic" />
+             </span>
+             <MatDialog heading={String::from("Dialog header")} dialog_link={self.basic_dialog_link.clone()}
+                 onclosing={Callback::from(|action| gloo_console::log!(&format!("onclosing action: {}", action)))}
+                 onclosed={Callback::from(|action| gloo_console::log!(&format!("closed action: {}", action)))}>
+                 {"Dialog body text"}
+                 <MatDialogAction action_type={ActionType::Primary} action={String::from("ok")}>
+                     <MatButton label="Action 2" />
+                 </MatDialogAction>
+                 <MatDialogAction action_type={ActionType::Secondary} action={String::from("cancel")}>
+                     <MatButton label="Action 1" />
+                 </MatDialogAction>
+             </MatDialog>
+         </section>
         }});
 
         let actions = with_raw_code!(actions { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::ShowActionDialog)>
-                <MatButton raised=true label="Actions" />
-            </span>
-            <MatDialog heading=Cow::from("Actions") dialog_link=self.action_dialog_link.clone()>
-                {"
+         <section>
+             <span onclick={link.callback(|_| Msg::ShowActionDialog)}>
+                 <MatButton raised=true label="Actions" />
+             </span>
+             <MatDialog heading={String::from("Actions")} dialog_link={self.action_dialog_link.clone()} >
+                 {"
                     By setting the dialog_action=\"my-action\" attribute on any element projected
                     into MatDialog, you can close the dialog by clicking on that element. The
                     dialog will then fire a non-bubbling \"closing\" event and a non-bubbling
                     \"closed\" event with an event detail of {action: \"my-action\"}
                 "}
 
-                <MatDialogAction action_type=ActionType::Primary action=Cow::from("customAction")>
-                    <MatButton label="This has action" />
-                </MatDialogAction>
-                <MatDialogAction action_type=ActionType::Secondary>
-                    <MatButton label="this does not" />
-                </MatDialogAction>
-            </MatDialog>
-        </section>
+                 <MatDialogAction action_type={ActionType::Primary} action={String::from("customAction")}>
+                     <MatButton label="This has action" />
+                 </MatDialogAction>
+                 <MatDialogAction action_type={ActionType::Secondary}>
+                     <MatButton label="this does not" />
+                 </MatDialogAction>
+             </MatDialog>
+         </section>
         }});
 
         let text = "Really long text will scroll";
         let text = text.repeat(100);
 
         let scrollable = with_raw_code!(scrollable { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::ShowScrollableDialog)>
-                <MatButton raised=true label="Scrollable" />
-            </span>
-            <MatDialog heading=Cow::from("Scrollable") dialog_link=self.scrollable_dialog_link.clone()>
-                {text}
-                <MatDialogAction action_type=ActionType::Primary action=Cow::from("close")>
-                    <MatButton label="Close this!" />
-                </MatDialogAction>
-            </MatDialog>
-        </section>
+         <section>
+             <span onclick={link.callback(|_| Msg::ShowScrollableDialog)}>
+                 <MatButton raised=true label="Scrollable" />
+             </span>
+             <MatDialog heading={String::from("Scrollable")} dialog_link={self.scrollable_dialog_link.clone()}>
+                 {text}
+                 <MatDialogAction action_type={ActionType::Primary} action={String::from("close")}>
+                     <MatButton label="Close this!" />
+                 </MatDialogAction>
+             </MatDialog>
+         </section>
         }});
 
         let hide_actions = with_raw_code!(hide_actions { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::ShowHideActionDialog)>
-                <MatButton raised=true label="Hide Actions" />
-            </span>
-            <MatDialog heading=Cow::from("Hide Actions") dialog_link=self.hide_action_dialog_link.clone() hide_action=self.hide_actions>
-                <p>{"
+         <section>
+             <span onclick={link.callback(|_| Msg::ShowHideActionDialog)}>
+                 <MatButton raised=true label="Hide Actions" />
+             </span>
+             <MatDialog heading={String::from("Hide Actions")} dialog_link={self.hide_action_dialog_link.clone()} hide_action={self.hide_actions}>
+                 <p>{"
                     If you don't have actions, you may want to set the \"hideActions\" property.
                     This property will remove extra whitespace at the bottom of this dialog.
                     This button will toggle that whitespace:
                 "}</p>
 
-                <span onclick=self.link.callback(|_| { Msg::HideActions })>
-                    <MatButton label="Toggle hideActions" />
-                </span>
-            </MatDialog>
-        </section>
+                 <span onclick={link.callback(|_| { Msg::HideActions })}>
+                     <MatButton label="Toggle hideActions" />
+                 </span>
+             </MatDialog>
+         </section>
         }});
 
         let stacked = with_raw_code!(stacked { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::ShowStackedDialog)>
-                <MatButton raised=true label="Stacked" />
-            </span>
-            <MatDialog heading=Cow::from("Stacked") dialog_link=self.stacked_dialog_link.clone() stacked=true>
-                {"
+         <section>
+             <span onclick={link.callback(|_| Msg::ShowStackedDialog)}>
+                 <MatButton raised=true label="Stacked" />
+             </span>
+             <MatDialog heading={String::from("Stacked")} dialog_link={self.stacked_dialog_link.clone()} stacked=true>
+                 {"
                     This is what happens when you set the stacked property on mwc-dialog.
                     Notice that the primary action is now on top.
                 "}
-                <MatDialogAction action_type=ActionType::Primary action=Cow::from("close")>
-                    <MatButton label="Primary" />
-                </MatDialogAction>
-                <MatDialogAction action_type=ActionType::Secondary action=Cow::from("close")>
-                    <MatButton label="Secondary" />
-                </MatDialogAction>
-            </MatDialog>
-        </section>
+                 <MatDialogAction action_type={ActionType::Primary} action={String::from("close")}>
+                     <MatButton label="Primary" />
+                 </MatDialogAction>
+                 <MatDialogAction action_type={ActionType::Secondary} action={String::from("close")}>
+                     <MatButton label="Secondary" />
+                 </MatDialogAction>
+             </MatDialog>
+         </section>
         }});
         /*
-        let initial_focus = with_raw_code!(initial_focus { html! {
+         let initial_focus = with_raw_code!(initial_focus { html! {
 
         }});
 
-        let form_validation = with_raw_code!(form_validation { html! {
+         let form_validation = with_raw_code!(form_validation { html! {
 
         }});*/
 
         html! {
-        <main>
-            <Codeblock code_and_html=basic title="Basic" />
+         <main>
+             <Codeblock code_and_html={basic} title="Basic" />
 
-            <Codeblock code_and_html=actions title="Actions" />
+             <Codeblock code_and_html={actions} title="Actions" />
 
-            <Codeblock code_and_html=scrollable title="Scrollable" />
+             <Codeblock code_and_html={scrollable} title="Scrollable" />
 
-            <Codeblock code_and_html=hide_actions title="Hide Actions" />
+             <Codeblock code_and_html={hide_actions} title="Hide Actions" />
 
-            <Codeblock code_and_html=stacked title="Stacked" />
-        </main>
+             <Codeblock code_and_html={stacked} title="Stacked" />
+         </main>
         }
     }
 }

--- a/website/src/components/drawer.rs
+++ b/website/src/components/drawer.rs
@@ -6,19 +6,11 @@ impl Component for Drawer {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         html! {<>
         <section>
             {"Need a way to iframe here. I apparently can't have 2 top app bars"}

--- a/website/src/components/fab.rs
+++ b/website/src/components/fab.rs
@@ -9,43 +9,35 @@ impl Component for Fab {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard_fab = with_raw_code!(standard_fab { html! {
-        <section class="demo">
-            <MatFab icon="edit" />
-        </section>
+         <section class="demo">
+             <MatFab icon="edit" />
+         </section>
         }});
 
         let mini_fab = with_raw_code!(mini_fab { html! {
-        <section class="demo">
-            <MatFab icon="add" mini=true />
-        </section>
+         <section class="demo">
+             <MatFab icon="add" mini=true />
+         </section>
         }});
 
         let extended_fab = with_raw_code!(extended_fab { html! {
-        <section class="demo">
-            <MatFab icon="shopping_cart" label="Add to cart" extended=true />
-        </section>
+         <section class="demo">
+             <MatFab icon="shopping_cart" label="Add to cart" extended=true />
+         </section>
         }});
 
         html! {<>
-            <Codeblock title="Standard" code_and_html=standard_fab />
+            <Codeblock title="Standard" code_and_html={standard_fab} />
 
-            <Codeblock title="Mini" code_and_html=mini_fab />
+            <Codeblock title="Mini" code_and_html={mini_fab} />
 
-            <Codeblock title="Extended" code_and_html=extended_fab />
+            <Codeblock title="Extended" code_and_html={extended_fab} />
         </>}
     }
 }

--- a/website/src/components/form_field.rs
+++ b/website/src/components/form_field.rs
@@ -9,19 +9,11 @@ impl Component for FormField {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let checkbox = with_raw_code!(checkbox { html! {
         <section>
             <div class="demo">
@@ -37,30 +29,30 @@ impl Component for FormField {
                     <MatCheckbox />
                 </MatFormfield>
             </div>
-        </section> }});
+        </section>}});
 
         let switch = with_raw_code!(switch { html! {
-        <section class="demo">
-            <MatFormfield label="This is a switch">
-                <MatSwitch />
-            </MatFormfield>
-        </section>
+         <section class="demo">
+             <MatFormfield label="This is a switch">
+                 <MatSwitch />
+             </MatFormfield>
+         </section>
         }});
 
         let radio = with_raw_code!(radio { html! {
-        <section class="demo">
-            <MatFormfield label="This is a radio button">
-                <MatRadio name="radio-name" />
-            </MatFormfield>
-        </section>
+         <section class="demo">
+             <MatFormfield label="This is a radio button">
+                 <MatRadio name="radio-name" />
+             </MatFormfield>
+         </section>
         }});
 
         html! {<>
-            <Codeblock title="Checkbox" code_and_html=checkbox />
+            <Codeblock title="Checkbox" code_and_html={checkbox} />
 
-            <Codeblock title="Switch" code_and_html=switch />
+            <Codeblock title="Switch" code_and_html={switch} />
 
-            <Codeblock title="Radio" code_and_html=radio />
+            <Codeblock title="Radio" code_and_html={radio} />
         </>}
     }
 }

--- a/website/src/components/home.rs
+++ b/website/src/components/home.rs
@@ -7,19 +7,11 @@ impl Component for Home {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let readme = include_str!("../../readme.html");
 
         html_to_element(readme)

--- a/website/src/components/icon.rs
+++ b/website/src/components/icon.rs
@@ -9,30 +9,22 @@ impl Component for Icon {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let icons = with_raw_code!(icons { html! {
-        <section class="demo">
-            <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
-            <MatIcon>{"sentiment_dissatisfied"}</MatIcon>
-            <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
-            <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
-            <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
-        </section>
+         <section class="demo">
+             <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
+             <MatIcon>{"sentiment_dissatisfied"}</MatIcon>
+             <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
+             <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
+             <MatIcon>{"sentiment_very_dissatisfied"}</MatIcon>
+         </section>
         }});
         html! {<>
-            <Codeblock title="Icons" code_and_html=icons />
+            <Codeblock title="Icons" code_and_html={icons} />
         </>}
     }
 }

--- a/website/src/components/icon_button.rs
+++ b/website/src/components/icon_button.rs
@@ -9,42 +9,34 @@ impl Component for IconButton {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard_icon_button = with_raw_code!(standard_icon_button { html! {
-        <section class="demo">
-            <MatIconButton icon="code"></MatIconButton>
-        </section>
+         <section class="demo">
+             <MatIconButton icon="code"></MatIconButton>
+         </section>
         }});
         let svg_icon_button = with_raw_code!(svg_icon_button { html! {
-         <section class="demo">
-            <MatIconButton>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"></path><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path></svg>
-            </MatIconButton>
-        </section>
+          <section class="demo">
+             <MatIconButton>
+                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"></path><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path></svg>
+             </MatIconButton>
+         </section>
         }});
         let disabled_icon_button = with_raw_code!(disabled_icon_button { html! {
-        <section class="demo">
-            <MatIconButton disabled=true icon="code"></MatIconButton>
-        </section>
+         <section class="demo">
+             <MatIconButton disabled=true icon="code"></MatIconButton>
+         </section>
         }});
         html! {<>
-            <Codeblock title="Standard" code_and_html=standard_icon_button />
+            <Codeblock title="Standard" code_and_html={standard_icon_button} />
 
-            <Codeblock title="SVG" code_and_html=svg_icon_button />
+            <Codeblock title="SVG" code_and_html={svg_icon_button} />
 
-            <Codeblock title="Disabled" code_and_html=disabled_icon_button />
+            <Codeblock title="Disabled" code_and_html={disabled_icon_button} />
         </>}
     }
 }

--- a/website/src/components/icon_button_toggle.rs
+++ b/website/src/components/icon_button_toggle.rs
@@ -7,7 +7,6 @@ use material_yew::{
 use yew::prelude::*;
 
 pub struct IconButtonToggle {
-    link: ComponentLink<Self>,
     state: bool,
 }
 
@@ -19,57 +18,54 @@ impl Component for IconButtonToggle {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { link, state: false }
+    fn create(_: &Context<Self>) -> Self {
+        Self { state: false }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Change(state) => self.state = state,
         };
         true
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let icon_button_toggle = with_raw_code!(icon_button_toggle { html! {
-        <section class="demo">
-            <div>
-                <MatIconButtonToggle on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" onchange=self.link.callback(Msg::Change) />
-                <br />
-                <span>{"State: "} {self.state}</span>
-            </div>
+         <section class="demo">
+             <div>
+                 <MatIconButtonToggle on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" onchange={link.callback(Msg::Change)} />
+                 <br />
+                 <span>{"State: "} {self.state}</span>
+             </div>
 
-            <MatIconButtonToggle>
-                <MatOnIconButtonToggle>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
-                </MatOnIconButtonToggle>
-                <MatOffIconButtonToggle>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
-                </MatOffIconButtonToggle>
-            </MatIconButtonToggle>
+             <MatIconButtonToggle>
+                 <MatOnIconButtonToggle>
+                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>
+                 </MatOnIconButtonToggle>
+                 <MatOffIconButtonToggle>
+                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z"/><path d="M16.59 7.58L10 14.17l-3.59-3.58L5 12l5 5 8-8zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
+                 </MatOffIconButtonToggle>
+             </MatIconButtonToggle>
 
-            <MatIconButtonToggle>
-                <MatOnIconButtonToggle>
-                    <img src="https://picsum.photos/id/28/24/24" />
-                </MatOnIconButtonToggle>
+             <MatIconButtonToggle>
+                 <MatOnIconButtonToggle>
+                     <img src="https://picsum.photos/id/28/24/24" />
+                 </MatOnIconButtonToggle>
 
-                <MatOffIconButtonToggle>
-                    <img src="https://picsum.photos/id/141/24/24?grayscale" />
-                </MatOffIconButtonToggle>
-            </MatIconButtonToggle>
+                 <MatOffIconButtonToggle>
+                     <img src="https://picsum.photos/id/141/24/24?grayscale" />
+                 </MatOffIconButtonToggle>
+             </MatIconButtonToggle>
 
-            <MatIconButtonToggle disabled=true on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" />
+             <MatIconButtonToggle disabled=true on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" />
 
-            <MatIconButtonToggle on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" />
-        </section>
+             <MatIconButtonToggle on_icon="sentiment_very_satisfied" off_icon="sentiment_very_dissatisfied" />
+         </section>
         }});
 
         html! {<>
-            <Codeblock title="Icon Button Toggle" code_and_html=icon_button_toggle />
+            <Codeblock title="Icon Button Toggle" code_and_html={icon_button_toggle} />
         </>}
     }
 }

--- a/website/src/components/linear_progress.rs
+++ b/website/src/components/linear_progress.rs
@@ -4,7 +4,6 @@ use material_yew::{MatButton, MatLinearProgress};
 use yew::prelude::*;
 
 pub struct LinearProgress {
-    link: ComponentLink<Self>,
     closed: bool,
     progress: f32,
 }
@@ -18,15 +17,14 @@ impl Component for LinearProgress {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
             closed: false,
-            link,
             progress: 0.0,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ChangeProgress => {
                 self.progress += 0.1;
@@ -38,48 +36,45 @@ impl Component for LinearProgress {
         true
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let buffer = self.progress - 0.3;
 
         let toggle = with_raw_code!(toggle { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::Close)>
-                <MatButton label="Toggle" raised=true  />
-             </span><br />
-            <div style="margin: 1em;">
-                <MatLinearProgress closed=self.closed progress=0.75 buffer=0.5 />
-            </div>
-        </section>
+         <section>
+             <span onclick={link.callback(|_| Msg::Close)}>
+                 <MatButton label="Toggle" raised=true  />
+              </span><br />
+             <div style="margin: 1em;">
+                 <MatLinearProgress closed={self.closed} progress=0.75 buffer=0.5 />
+             </div>
+         </section>
         }});
 
         let indeterminate = with_raw_code!(indeterminate { html! {
-        <section>
-            <div style="margin: 1em;">
-                <MatLinearProgress indeterminate=true />
-            </div>
-        </section>
+         <section>
+             <div style="margin: 1em;">
+                 <MatLinearProgress indeterminate=true />
+             </div>
+         </section>
         }});
 
         let determinate = with_raw_code!(determinate { html! {
-        <section>
-            <span onclick=self.link.callback(|_| Msg::ChangeProgress)>
-                <MatButton label="Increase progress" raised=true />
-            </span> <br />
-            <div style="margin: 1em;">
-                <MatLinearProgress progress=self.progress buffer=buffer />
-            </div>
-        </section>
+         <section>
+             <span onclick={link.callback(|_| Msg::ChangeProgress)}>
+                 <MatButton label="Increase progress" raised=true />
+             </span> <br />
+             <div style="margin: 1em;">
+                 <MatLinearProgress progress={self.progress} buffer={buffer} />
+             </div>
+         </section>
         }});
         html! {<>
-            <Codeblock title="Toggle Linear Progress" code_and_html=toggle />
+            <Codeblock title="Toggle Linear Progress" code_and_html={toggle} />
 
-            <Codeblock title="Indeterminate Linear Progress" code_and_html=indeterminate />
+            <Codeblock title="Indeterminate Linear Progress" code_and_html={indeterminate} />
 
-            <Codeblock title="Determinate Linear Progress" code_and_html=determinate />
+            <Codeblock title="Determinate Linear Progress" code_and_html={determinate} />
         </>}
     }
 }

--- a/website/src/components/list.rs
+++ b/website/src/components/list.rs
@@ -7,7 +7,6 @@ use material_yew::{
 use yew::prelude::*;
 
 pub struct List {
-    link: ComponentLink<Self>,
     list_link: WeakComponentLink<MatList>,
     basic_selected_index: String,
     activatable_selected_index: String,
@@ -25,9 +24,8 @@ impl Component for List {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             basic_selected_index: "".to_string(),
             activatable_selected_index: "".to_string(),
             checklist_selected_index: "".to_string(),
@@ -37,7 +35,7 @@ impl Component for List {
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         let transform = |v| {
             match v {
                 ListIndex::Single(o) => {
@@ -77,99 +75,96 @@ impl Component for List {
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let basic = with_raw_code!(basic { html! {
-        <section>
-            <MatList onaction=self.link.callback(|val| Msg::Action(val, "basic")) list_link=self.list_link.clone()>
-                <MatListItem>{"Item 0"}</MatListItem>
-                <MatListItem>{"Item 1"}</MatListItem>
-                <MatListItem>{"Item 2"}</MatListItem>
-                <MatListItem>{"Item 3"}</MatListItem>
-            </MatList>
-            <div>{"Selected index: "}{&self.basic_selected_index}</div>
-            <div onclick=self.link.callback(|_| Msg::Focus)>
-                <MatButton label="Focus index 2" raised=true />
-            </div>
-        </section>
+         <section>
+             <MatList onaction={link.callback(|val| Msg::Action(val, "basic"))} list_link={self.list_link.clone()}>
+                 <MatListItem>{"Item 0"}</MatListItem>
+                 <MatListItem>{"Item 1"}</MatListItem>
+                 <MatListItem>{"Item 2"}</MatListItem>
+                 <MatListItem>{"Item 3"}</MatListItem>
+             </MatList>
+             <div>{"Selected index: "}{&self.basic_selected_index}</div>
+             <div onclick={link.callback(|_| Msg::Focus)}>
+                 <MatButton label="Focus index 2" raised=true />
+             </div>
+         </section>
         }});
 
         let multi_activatable = with_raw_code!(multi_activatable { html! {
-        <section>
-            <MatList onaction=self.link.callback(|val| Msg::Action(val, "multi")) multi=true activatable=true>
-                <MatListItem>{"Item 0"}</MatListItem>
-                <MatListItem>{"Item 1"}</MatListItem>
-                <MatListItem>{"Item 2"}</MatListItem>
-                <MatListItem>{"Item 3"}</MatListItem>
-            </MatList>
+         <section>
+             <MatList onaction={link.callback(|val| Msg::Action(val, "multi"))} multi=true activatable=true>
+                 <MatListItem>{"Item 0"}</MatListItem>
+                 <MatListItem>{"Item 1"}</MatListItem>
+                 <MatListItem>{"Item 2"}</MatListItem>
+                 <MatListItem>{"Item 3"}</MatListItem>
+             </MatList>
 
-            <span>{"Selected index: "}{&self.multi_selected_index}</span>
-        </section>
+             <span>{"Selected index: "}{&self.multi_selected_index}</span>
+         </section>
         }});
 
         let activatable = with_raw_code!(activatable { html! {
-        <section>
-            <MatList activatable=true onaction=self.link.callback(|val| Msg::Action(val, "activatable"))>
-                <MatListItem>{"Item 0"}</MatListItem>
-                <MatListItem>{"Item 1"}</MatListItem>
-                <MatListItem>{"Item 2"}</MatListItem>
-                <MatListItem>{"Item 3"}</MatListItem>
-            </MatList>
+         <section>
+             <MatList activatable=true onaction={link.callback(|val| Msg::Action(val, "activatable"))}>
+                 <MatListItem>{"Item 0"}</MatListItem>
+                 <MatListItem>{"Item 1"}</MatListItem>
+                 <MatListItem>{"Item 2"}</MatListItem>
+                 <MatListItem>{"Item 3"}</MatListItem>
+             </MatList>
 
-            <span>{"Selected index: "}{&self.activatable_selected_index}</span>
-        </section>
+             <span>{"Selected index: "}{&self.activatable_selected_index}</span>
+         </section>
         }});
 
         let non_interactive = with_raw_code!(non_interactive { html! {
-        <section>
-            <MatList noninteractive=true>
-                <MatListItem>{"Item 0"}</MatListItem>
-                <MatListItem>{"Item 1"}</MatListItem>
-                <MatListItem>{"Item 2"}</MatListItem>
-                <MatListItem>{"Item 3"}</MatListItem>
-            </MatList>
-        </section>
+         <section>
+             <MatList noninteractive=true>
+                 <MatListItem>{"Item 0"}</MatListItem>
+                 <MatListItem>{"Item 1"}</MatListItem>
+                 <MatListItem>{"Item 2"}</MatListItem>
+                 <MatListItem>{"Item 3"}</MatListItem>
+             </MatList>
+         </section>
         }});
 
         let checklist = with_raw_code!(checklist { html! {
-        <section>
-            <MatList onaction=self.link.callback(|val| Msg::Action(val, "checklist"))>
-                <MatCheckListItem>{"Item 0"}</MatCheckListItem>
-                <MatCheckListItem>{"Item 1"}</MatCheckListItem>
-                <MatCheckListItem left=true>{"Item 2"}</MatCheckListItem>
-                <MatCheckListItem left=true>{"Item 3"}</MatCheckListItem>
-                // Text needs be in a span (or any other element) to be displayed correctly
-                // Blame Material components
-                <MatCheckListItem disabled=true><span>{"Disabled"}</span></MatCheckListItem>
-            </MatList>
+         <section>
+             <MatList onaction={link.callback(|val| Msg::Action(val, "checklist"))}>
+                 <MatCheckListItem>{"Item 0"}</MatCheckListItem>
+                 <MatCheckListItem>{"Item 1"}</MatCheckListItem>
+                 <MatCheckListItem left=true>{"Item 2"}</MatCheckListItem>
+                 <MatCheckListItem left=true>{"Item 3"}</MatCheckListItem>
+                 // Text needs be in a span (or any other element) to be displayed correctly
+                 // Blame Material components
+                 <MatCheckListItem disabled=true><span>{"Disabled"}</span></MatCheckListItem>
+             </MatList>
 
-            <span>{"Selected index: "}{&self.checklist_selected_index}</span>
-        </section>
+             <span>{"Selected index: "}{&self.checklist_selected_index}</span>
+         </section>
         }});
 
         let radio_list = with_raw_code!(radio_list { html! {
-        <section>
-            <MatList onaction=self.link.callback(|val| Msg::Action(val, "radio"))>
-                <MatRadioListItem>{"Item 0"}</MatRadioListItem>
-                <MatRadioListItem>{"Item 1"}</MatRadioListItem>
-                <MatRadioListItem left=true>{"Item 2"}</MatRadioListItem>
-                <MatRadioListItem left=true>{"Item 3"}</MatRadioListItem>
-            </MatList>
+         <section>
+             <MatList onaction={link.callback(|val| Msg::Action(val, "radio"))}>
+                 <MatRadioListItem>{"Item 0"}</MatRadioListItem>
+                 <MatRadioListItem>{"Item 1"}</MatRadioListItem>
+                 <MatRadioListItem left=true>{"Item 2"}</MatRadioListItem>
+                 <MatRadioListItem left=true>{"Item 3"}</MatRadioListItem>
+             </MatList>
 
-            <span>{"Selected index: "}{&self.radio_selected_index}</span>
-        </section>
+             <span>{"Selected index: "}{&self.radio_selected_index}</span>
+         </section>
         }});
 
         html! {<main class="list-demo">
-            <Codeblock title="Basic" code_and_html=basic />
-            <Codeblock title="Multi + Activatable" code_and_html=multi_activatable />
-            <Codeblock title="Activatable" code_and_html=activatable />
-            <Codeblock title="Non-interactive" code_and_html=non_interactive />
-            <Codeblock title="Checklist" code_and_html=checklist />
-            <Codeblock title="Radio list" code_and_html=radio_list />
+            <Codeblock title="Basic" code_and_html={basic} />
+            <Codeblock title="Multi + Activatable" code_and_html={multi_activatable} />
+            <Codeblock title="Activatable" code_and_html={activatable} />
+            <Codeblock title="Non-interactive" code_and_html={non_interactive} />
+            <Codeblock title="Checklist" code_and_html={checklist} />
+            <Codeblock title="Radio list" code_and_html={radio_list} />
         </main>}
     }
 }

--- a/website/src/components/menu.rs
+++ b/website/src/components/menu.rs
@@ -16,6 +16,7 @@ pub struct Menu {
     multi_activatable_menu_link: WeakComponentLink<MatMenu>,
 }
 
+#[allow(clippy::enum_variant_names)]
 pub enum Msg {
     ShowBasicMenu,
     ShowCornerMenu,

--- a/website/src/components/menu.rs
+++ b/website/src/components/menu.rs
@@ -5,7 +5,6 @@ use material_yew::{MatButton, MatListItem, MatMenu, WeakComponentLink};
 use yew::prelude::*;
 
 pub struct Menu {
-    link: ComponentLink<Self>,
     basic_menu_link: WeakComponentLink<MatMenu>,
     corner_menu_link: WeakComponentLink<MatMenu>,
     quick_menu_link: WeakComponentLink<MatMenu>,
@@ -33,9 +32,8 @@ impl Component for Menu {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             basic_menu_link: WeakComponentLink::default(),
             corner_menu_link: WeakComponentLink::default(),
             quick_menu_link: WeakComponentLink::default(),
@@ -48,7 +46,7 @@ impl Component for Menu {
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ShowBasicMenu => self.basic_menu_link.show(),
             Msg::ShowCornerMenu => self.corner_menu_link.show(),
@@ -63,197 +61,194 @@ impl Component for Menu {
         false
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let basic_menu = with_raw_code!(basic_menu { html! {
-        <div style="position:relative;">
-            <span onclick=self.link.callback(|_| Msg::ShowBasicMenu)>
-                <MatButton raised=true label="Open Basic Menu"></MatButton>
-            </span>
-            <MatMenu menu_link=self.basic_menu_link.clone()>
-                <MatListItem>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div style="position:relative;">
+             <span onclick={link.callback(|_| Msg::ShowBasicMenu)}>
+                 <MatButton raised=true label="Open Basic Menu"></MatButton>
+             </span>
+             <MatMenu menu_link={self.basic_menu_link.clone()}>
+                 <MatListItem>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         let corner_menu = with_raw_code!(corner_menu { html! {
-        <div style="position:relative;">
-            <span onclick=self.link.callback(|_| Msg::ShowCornerMenu)>
-                <MatButton
-                    raised=true
-                    label="Open Menu in BottomRight Corner">
-                </MatButton>
-            </span>
-            // TODO allow user to enter corner value
-            <MatMenu corner=Corner::BottomRight menu_link=self.corner_menu_link.clone()>
-                <MatListItem>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div style="position:relative;">
+             <span onclick={link.callback(|_| Msg::ShowCornerMenu)}>
+                 <MatButton
+                     raised=true
+                     label="Open Menu in BottomRight Corner">
+                 </MatButton>
+             </span>
+             // TODO allow user to enter corner value
+             <MatMenu corner={Corner::BottomRight} menu_link={self.corner_menu_link.clone()}>
+                 <MatListItem>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         let quick_menu = with_raw_code!(quick_menu { html! {
-        <div style="position:relative;">
-            <span onclick=self.link.callback(|_| Msg::ShowQuickMenu)>
-                <MatButton raised=true label="Open Quick Menu"></MatButton>
-            </span>
-            <MatMenu quick=true menu_link=self.quick_menu_link.clone()>
-                <MatListItem>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div style="position:relative;">
+             <span onclick={link.callback(|_| Msg::ShowQuickMenu)}>
+                 <MatButton raised=true label="Open Quick Menu"></MatButton>
+             </span>
+             <MatMenu quick=true menu_link={self.quick_menu_link.clone()}>
+                 <MatListItem>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         let scrollable = with_raw_code!(scrollable_menu { html! {
-        <div class="scrollable">
-            <span>
-                <span onclick=self.link.callback(|_| Msg::ShowFixedMenu)>
-                    <MatButton raised=true label="Open Fixed Menu"></MatButton>
-                </span>
-                <MatMenu fixed=true menu_link=self.fixed_menu_link.clone()>
-                    <MatListItem>{"one"}</MatListItem>
-                    <MatListItem>{"two"}</MatListItem>
-                    <MatListItem>{"three"}</MatListItem>
-                    <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                    <li divider="true"></li>
-                    <MatListItem>{"aaa"}</MatListItem>
-                    <MatListItem>{"bbb"}</MatListItem>
-                </MatMenu>
-            </span>
+         <div class="scrollable">
+             <span>
+                 <span onclick={link.callback(|_| Msg::ShowFixedMenu)}>
+                     <MatButton raised=true label="Open Fixed Menu"></MatButton>
+                 </span>
+                 <MatMenu fixed=true menu_link={self.fixed_menu_link.clone()}>
+                     <MatListItem>{"one"}</MatListItem>
+                     <MatListItem>{"two"}</MatListItem>
+                     <MatListItem>{"three"}</MatListItem>
+                     <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                     <li divider="true"></li>
+                     <MatListItem>{"aaa"}</MatListItem>
+                     <MatListItem>{"bbb"}</MatListItem>
+                 </MatMenu>
+             </span>
 
-            <span style="position:relative;">
-                <span onclick=self.link.callback(|_| Msg::ShowNonFixedMenu)>
-                    <MatButton raised=true label="Open Non-Fixed Menu"></MatButton>
-                </span>
-                <MatMenu menu_link=self.non_fixed_menu_link.clone()>
-                    <MatListItem>{"one"}</MatListItem>
-                    <MatListItem>{"two"}</MatListItem>
-                    <MatListItem>{"three"}</MatListItem>
-                    <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                    <li divider="true"></li>
-                    <MatListItem>{"aaa"}</MatListItem>
-                    <MatListItem>{"bbb"}</MatListItem>
-                </MatMenu>
-            </span>
-            <div>{"Open each menu and then scroll this div"}</div>
-            <div class="spacer"></div>
-        </div>
+             <span style="position:relative;">
+                 <span onclick={link.callback(|_| Msg::ShowNonFixedMenu)}>
+                     <MatButton raised=true label="Open Non-Fixed Menu"></MatButton>
+                 </span>
+                 <MatMenu menu_link={self.non_fixed_menu_link.clone()}>
+                     <MatListItem>{"one"}</MatListItem>
+                     <MatListItem>{"two"}</MatListItem>
+                     <MatListItem>{"three"}</MatListItem>
+                     <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                     <li divider="true"></li>
+                     <MatListItem>{"aaa"}</MatListItem>
+                     <MatListItem>{"bbb"}</MatListItem>
+                 </MatMenu>
+             </span>
+             <div>{"Open each menu and then scroll this div"}</div>
+             <div class="spacer"></div>
+         </div>
         }});
 
         let absolute_menu_no_anchor = with_raw_code!(absolute_menu_no_anchor { html! {
-        <div>
-            <span onclick=self.link.callback(|_| Msg::ShowAbsoluteMenuNoAnchor)>
-                <MatButton raised=true label="Open Absolute Menu (no anchor)"></MatButton>
-            </span>
-            <MatMenu
-                absolute=true
-                x=0
-                y=0
-                menu_link=self.absolute_menu_no_anchor_link.clone()
-            >
-                <MatListItem>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div>
+             <span onclick={link.callback(|_| Msg::ShowAbsoluteMenuNoAnchor)}>
+                 <MatButton raised=true label="Open Absolute Menu (no anchor)"></MatButton>
+             </span>
+             <MatMenu
+                 absolute=true
+                 x=0
+                 y=0
+                 menu_link={self.absolute_menu_no_anchor_link.clone()}
+             >
+                 <MatListItem>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         let activatable_menu = with_raw_code!(activatable_menu { html! {
-        <div style="position:relative;">
-            <span onclick=self.link.callback(|_| Msg::ShowActivatableMenu)>
-                <MatButton raised=true label="Open Activatable Menu"></MatButton>
-            </span>
-            <MatMenu activatable=true menu_link=self.activatable_menu_link.clone()>
-                <MatListItem>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div style="position:relative;">
+             <span onclick={link.callback(|_| Msg::ShowActivatableMenu)}>
+                 <MatButton raised=true label="Open Activatable Menu"></MatButton>
+             </span>
+             <MatMenu activatable=true menu_link={self.activatable_menu_link.clone()}>
+                 <MatListItem>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         let multi_activatable_menu = with_raw_code!(multi_activatable_menu { html! {
-        <div style="position:relative;">
-            <span onclick=self.link.callback(|_| Msg::ShowMultiActivatableMenu)>
-                <MatButton raised=true label="Open Multi (activatable) Menu"></MatButton>
-            </span>
-            <MatMenu multi=true activatable=true menu_link=self.multi_activatable_menu_link.clone()>
-                <MatListItem selected=true activated=true>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem selected=true activated=true>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div style="position:relative;">
+             <span onclick={link.callback(|_| Msg::ShowMultiActivatableMenu)}>
+                 <MatButton raised=true label="Open Multi (activatable) Menu"></MatButton>
+             </span>
+             <MatMenu multi=true activatable=true menu_link={self.multi_activatable_menu_link.clone()}>
+                 <MatListItem selected=true activated=true>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem selected=true activated=true>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         let default_focus_menu = with_raw_code!(default_focus_menu { html! {
-        <div style="position:relative;">
-            <span onclick=self.link.callback(|_| Msg::ShowDefaultFoucsMenu)>
-                <MatButton
-                    raised=true
-                    label="Open Menu With Default Focus with focus of LastItem">
-                </MatButton>
-            </span>
-            // TODO allow user to enter corner value
-            <MatMenu default_focus=DefaultFocusState::LastItem menu_link=self.default_focus_menu_link.clone()>
-                <MatListItem>{"one"}</MatListItem>
-                <MatListItem>{"two"}</MatListItem>
-                <MatListItem>{"three"}</MatListItem>
-                <MatListItem disabled=true><div>{"four"}</div></MatListItem>
-                <li divider="true"></li>
-                <MatListItem>{"aaa"}</MatListItem>
-                <MatListItem>{"bbb"}</MatListItem>
-            </MatMenu>
-        </div>
+         <div style="position:relative;">
+             <span onclick={link.callback(|_| Msg::ShowDefaultFoucsMenu)}>
+                 <MatButton
+                     raised=true
+                     label="Open Menu With Default Focus with focus of LastItem">
+                 </MatButton>
+             </span>
+             // TODO allow user to enter corner value
+             <MatMenu default_focus={DefaultFocusState::LastItem} menu_link={self.default_focus_menu_link.clone()}>
+                 <MatListItem>{"one"}</MatListItem>
+                 <MatListItem>{"two"}</MatListItem>
+                 <MatListItem>{"three"}</MatListItem>
+                 <MatListItem disabled=true><div>{"four"}</div></MatListItem>
+                 <li divider="true"></li>
+                 <MatListItem>{"aaa"}</MatListItem>
+                 <MatListItem>{"bbb"}</MatListItem>
+             </MatMenu>
+         </div>
         }});
 
         html! {
-            <main id="menu-demo">
-            <Codeblock code_and_html=basic_menu title="Basic Menu" />
+             <main id="menu-demo">
+             <Codeblock code_and_html={basic_menu} title="Basic Menu" />
 
-            <Codeblock code_and_html=corner_menu title="Corner Menu" />
+             <Codeblock code_and_html={corner_menu} title="Corner Menu" />
 
-            <Codeblock code_and_html=quick_menu title="Quick Menu" />
+             <Codeblock code_and_html={quick_menu} title="Quick Menu" />
 
-            <Codeblock code_and_html=scrollable title="Scrollable menu" />
+             <Codeblock code_and_html={scrollable} title="Scrollable menu" />
 
-            <Codeblock code_and_html=absolute_menu_no_anchor title="Absolute Menu (no anchor)" />
+             <Codeblock code_and_html={absolute_menu_no_anchor} title="Absolute Menu (no anchor)" />
 
-            <Codeblock code_and_html=activatable_menu title="Activatable Menu" />
+             <Codeblock code_and_html={activatable_menu} title="Activatable Menu" />
 
-            <Codeblock code_and_html=multi_activatable_menu title="Multi (activatable) Menu" />
+             <Codeblock code_and_html={multi_activatable_menu} title="Multi (activatable) Menu" />
 
-            <Codeblock code_and_html=default_focus_menu title="Menu With Default Focus" />
-        </main>
+             <Codeblock code_and_html={default_focus_menu} title="Menu With Default Focus" />
+         </main>
         }
     }
 }

--- a/website/src/components/radio.rs
+++ b/website/src/components/radio.rs
@@ -9,41 +9,33 @@ impl Component for Radio {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard = with_raw_code!(standard { html! {
-        <section class="demo">
-            <MatRadio name="some name" />
-        </section>
+         <section class="demo">
+             <MatRadio name="some name" />
+         </section>
         }});
         let checked = with_raw_code!(checked { html! {
-        <section class="demo">
-            <MatRadio checked=true />
-        </section>
+         <section class="demo">
+             <MatRadio checked=true />
+         </section>
         }});
         let disabled = with_raw_code!(disabled { html! {
-        <section class="demo">
-            <MatRadio disabled=true />
-        </section>
+         <section class="demo">
+             <MatRadio disabled=true />
+         </section>
         }});
 
         html! {<>
-            <Codeblock title="Standard Radio" code_and_html=standard />
+            <Codeblock title="Standard Radio" code_and_html={standard} />
 
-            <Codeblock title="Checked Radio" code_and_html=checked />
+            <Codeblock title="Checked Radio" code_and_html={checked} />
 
-            <Codeblock title="Disabled Radio" code_and_html=disabled />
+            <Codeblock title="Disabled Radio" code_and_html={disabled} />
         </>}
     }
 }

--- a/website/src/components/select.rs
+++ b/website/src/components/select.rs
@@ -5,7 +5,6 @@ use material_yew::{MatButton, MatListItem, MatSelect, WeakComponentLink};
 use yew::prelude::*;
 
 pub struct Select {
-    link: ComponentLink<Self>,
     natural_menu_width: bool,
     select_link: WeakComponentLink<MatSelect>,
 }
@@ -19,16 +18,15 @@ impl Component for Select {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         let select_link = WeakComponentLink::default();
         Self {
-            link,
             natural_menu_width: true,
             select_link,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ToggleNaturalMenuWidth => {
                 self.natural_menu_width = !self.natural_menu_width;
@@ -41,131 +39,128 @@ impl Component for Select {
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let filled = with_raw_code!(filled { html! {
-        <section>
-            <MatSelect label="Filled" select_link=self.select_link.clone()>
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1">{"Option 1"}</MatListItem>
-                <MatListItem value="2">{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-            <span onclick=self.link.callback(|_| Msg::SelectIndex2)>
-                <MatButton label="Select 'Option 1'"/>
-            </span>
-        </section>
+         <section>
+             <MatSelect label="Filled" select_link={self.select_link.clone()}>
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1">{"Option 1"}</MatListItem>
+                 <MatListItem value="2">{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+             <span onclick={link.callback(|_| Msg::SelectIndex2)}>
+                 <MatButton label="Select 'Option 1'"/>
+             </span>
+         </section>
         }});
 
         let outlined = with_raw_code!(outlined { html! {
-        <section>
-            <MatSelect label="Outlined" outlined=true>
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1">{"Option 1"}</MatListItem>
-                <MatListItem value="2">{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-        </section>
+         <section>
+             <MatSelect label="Outlined" outlined=true>
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1">{"Option 1"}</MatListItem>
+                 <MatListItem value="2">{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+         </section>
         }});
 
         let preselected = with_raw_code!(preselected { html! {
-        <section>
-            <MatSelect label="Preselected">
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1">{"Option 1"}</MatListItem>
-                <MatListItem value="2" selected=true>{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-        </section>
+         <section>
+             <MatSelect label="Preselected">
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1">{"Option 1"}</MatListItem>
+                 <MatListItem value="2" selected=true>{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+         </section>
         }});
 
         let has_icon = with_raw_code!(has_icon { html! {
-        <section>
-            <MatSelect label="Has Icon" outlined=true icon="event">
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0" graphic=GraphicType::Icon>{"Option 0"}</MatListItem>
-                <MatListItem value="1" graphic=GraphicType::Icon>{"Option 1"}</MatListItem>
-                <MatListItem value="2" graphic=GraphicType::Icon>{"Option 2"}</MatListItem>
-                <MatListItem value="3" graphic=GraphicType::Icon>{"Option 3"}</MatListItem>
-            </MatSelect>
-        </section>
+         <section>
+             <MatSelect label="Has Icon" outlined=true icon="event">
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0" graphic={GraphicType::Icon}>{"Option 0"}</MatListItem>
+                 <MatListItem value="1" graphic={GraphicType::Icon}>{"Option 1"}</MatListItem>
+                 <MatListItem value="2" graphic={GraphicType::Icon}>{"Option 2"}</MatListItem>
+                 <MatListItem value="3" graphic={GraphicType::Icon}>{"Option 3"}</MatListItem>
+             </MatSelect>
+         </section>
         }});
 
         let required = with_raw_code!(required { html! {
-        <section>
-            <MatSelect label="Required filled" required=true>
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1">{"Option 1"}</MatListItem>
-                <MatListItem value="2">{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-        </section>
+         <section>
+             <MatSelect label="Required filled" required=true>
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1">{"Option 1"}</MatListItem>
+                 <MatListItem value="2">{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+         </section>
         }});
 
         let required_outlined = with_raw_code!(required_outlined { html! {
-        <section>
-            <MatSelect label="Required outlined" required=true outlined=true>
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1">{"Option 1"}</MatListItem>
-                <MatListItem value="2">{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-        </section>
+         <section>
+             <MatSelect label="Required outlined" required=true outlined=true>
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1">{"Option 1"}</MatListItem>
+                 <MatListItem value="2">{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+         </section>
         }});
 
         let disabled = with_raw_code!(disabled { html! {
-        <section>
-            <MatSelect label="Disabled" disabled=true>
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1" disabled=true>{"Option 1"}</MatListItem>
-                <MatListItem value="2">{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-        </section>
+         <section>
+             <MatSelect label="Disabled" disabled=true>
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1" disabled=true>{"Option 1"}</MatListItem>
+                 <MatListItem value="2">{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+         </section>
         }});
 
         let natural_width = with_raw_code!(natural_width { html! {
-        <section>
-            <MatSelect label="Natural width" natural_menu_width=self.natural_menu_width>
-                <MatListItem>{""}</MatListItem>
-                <MatListItem value="0">{"Option 0"}</MatListItem>
-                <MatListItem value="1">{"Option 1"}</MatListItem>
-                <MatListItem value="2">{"Option 2"}</MatListItem>
-                <MatListItem value="3">{"Option 3"}</MatListItem>
-            </MatSelect>
-            <div onclick=self.link.callback(|_| Msg::ToggleNaturalMenuWidth)>
-                <MatButton label="Toggle natural menu width" raised=true />
-            </div>
-        </section>
+         <section>
+             <MatSelect label="Natural width" natural_menu_width={self.natural_menu_width}>
+                 <MatListItem>{""}</MatListItem>
+                 <MatListItem value="0">{"Option 0"}</MatListItem>
+                 <MatListItem value="1">{"Option 1"}</MatListItem>
+                 <MatListItem value="2">{"Option 2"}</MatListItem>
+                 <MatListItem value="3">{"Option 3"}</MatListItem>
+             </MatSelect>
+             <div onclick={link.callback(|_| Msg::ToggleNaturalMenuWidth)}>
+                 <MatButton label="Toggle natural menu width" raised=true />
+             </div>
+         </section>
         }});
 
         html! {
         <main class="list-demo">
 
-            <Codeblock title="Filled" code_and_html=filled />
+            <Codeblock title="Filled" code_and_html={filled} />
 
-            <Codeblock title="Outlined" code_and_html=outlined />
+            <Codeblock title="Outlined" code_and_html={outlined} />
 
-            <Codeblock title="Preselected" code_and_html=preselected />
+            <Codeblock title="Preselected" code_and_html={preselected} />
 
-            <Codeblock title="Has Icon" code_and_html=has_icon />
+            <Codeblock title="Has Icon" code_and_html={has_icon} />
 
-            <Codeblock title="Required" code_and_html=required />
+            <Codeblock title="Required" code_and_html={required} />
 
-            <Codeblock title="Required outlined" code_and_html=required_outlined />
+            <Codeblock title="Required outlined" code_and_html={required_outlined} />
 
-            <Codeblock title="Disabled" code_and_html=disabled />
+            <Codeblock title="Disabled" code_and_html={disabled} />
 
-            <Codeblock title="Natural width" code_and_html=natural_width />
+            <Codeblock title="Natural width" code_and_html={natural_width} />
 
         </main>}
     }

--- a/website/src/components/slider.rs
+++ b/website/src/components/slider.rs
@@ -9,35 +9,27 @@ impl Component for Slider {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let continuous = with_raw_code!(continuous { html! {
-        <section class="demo">
-            <MatSlider />
-        </section>
+         <section class="demo">
+             <MatSlider />
+         </section>
         }});
 
         let discrete = with_raw_code!(discrete { html! {
-        <section class="demo">
-            <MatSlider max=50 value=10 step=5 />
-        </section>
+         <section class="demo">
+             <MatSlider max=50 value=10 step=5 />
+         </section>
         }});
 
         html! {<main id="slider-demo">
-            <Codeblock title="Continuous Slider" code_and_html=continuous />
+            <Codeblock title="Continuous Slider" code_and_html={continuous} />
 
-            <Codeblock title="Discrete Slider" code_and_html=discrete />
+            <Codeblock title="Discrete Slider" code_and_html={discrete} />
 
             /* Undocumented so `disabled` exist
             <section class="comp-demo">

--- a/website/src/components/snackbar.rs
+++ b/website/src/components/snackbar.rs
@@ -2,10 +2,8 @@ use crate::components::Codeblock;
 use crate::with_raw_code;
 use material_yew::{MatButton, MatIconButton, MatSnackbar, WeakComponentLink};
 use yew::prelude::*;
-use yew::services::ConsoleService;
 
 pub struct Snackbar {
-    link: ComponentLink<Self>,
     default_link: WeakComponentLink<MatSnackbar>,
     leading_link: WeakComponentLink<MatSnackbar>,
     stacked_link: WeakComponentLink<MatSnackbar>,
@@ -24,16 +22,15 @@ impl Component for Snackbar {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             default_link: WeakComponentLink::default(),
             leading_link: WeakComponentLink::default(),
             stacked_link: WeakComponentLink::default(),
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::OpenDefault => {
                 self.default_link.show();
@@ -45,83 +42,80 @@ impl Component for Snackbar {
                 self.stacked_link.show();
             }
             Msg::DefaultClosed(reason) => {
-                ConsoleService::log(&format!("default closed with reason {:?}", reason))
+                gloo_console::log!(&format!("default closed with reason {:?}", reason))
             }
             Msg::LeadingClosed(reason) => {
-                ConsoleService::log(&format!("leading closed with reason {:?}", reason))
+                gloo_console::log!(&format!("leading closed with reason {:?}", reason))
             }
             Msg::StackedClosed(reason) => {
-                ConsoleService::log(&format!("stacked closed with reason {:?}", reason))
+                gloo_console::log!(&format!("stacked closed with reason {:?}", reason))
             }
         }
         false
     }
 
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let default = with_raw_code!(default { html! {
-        <section style="margin: 1em 0;">
-            <span onclick=self.link.callback(|_| Msg::OpenDefault)>
-                <MatButton label="Open default snackbar" raised=true  />
-             </span>
-            <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." snackbar_link=self.default_link.clone()
-                onclosed=self.link.callback(Msg::DefaultClosed)>
-                <span slot="action">
-                    <MatButton label="RETRY" />
-                </span>
+         <section style="margin: 1em 0;">
+             <span onclick={link.callback(|_| Msg::OpenDefault)}>
+                 <MatButton label="Open default snackbar" raised=true  />
+              </span>
+             <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." snackbar_link={self.default_link.clone()}
+                 onclosed={link.callback(Msg::DefaultClosed)}>
+                 <span slot="action">
+                     <MatButton label="RETRY" />
+                 </span>
 
-                <span class="snackbar-dismiss-slot" slot="dismiss">
-                    <MatIconButton icon="close" />
-                </span>
-            </MatSnackbar>
-        </section>
+                 <span class="snackbar-dismiss-slot" slot="dismiss">
+                     <MatIconButton icon="close" />
+                 </span>
+             </MatSnackbar>
+         </section>
         }});
 
         let leading = with_raw_code!(leading { html! {
-        <section style="margin: 1em 0;">
-            <span onclick=self.link.callback(|_| Msg::OpenLeading)>
-                <MatButton label="Open leading snackbar" raised=true  />
-             </span>
-            <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." snackbar_link=self.leading_link.clone() leading=true
-                onclosed=self.link.callback(Msg::LeadingClosed)>
-                <span slot="action">
-                    <MatButton label="RETRY" />
-                </span>
+         <section style="margin: 1em 0;">
+             <span onclick={link.callback(|_| Msg::OpenLeading)}>
+                 <MatButton label="Open leading snackbar" raised=true  />
+              </span>
+             <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." snackbar_link={self.leading_link.clone()} leading=true
+                 onclosed={link.callback(Msg::LeadingClosed)}>
+                 <span slot="action">
+                     <MatButton label="RETRY" />
+                 </span>
 
-                <span class="snackbar-dismiss-slot" slot="dismiss">
-                    <MatIconButton icon="close" />
-                </span>
-            </MatSnackbar>
-        </section>
+                 <span class="snackbar-dismiss-slot" slot="dismiss">
+                     <MatIconButton icon="close" />
+                 </span>
+             </MatSnackbar>
+         </section>
         }});
 
         let stacked = with_raw_code!(stacked { html! {
-        <section style="margin: 1em 0;">
-            <span onclick=self.link.callback(|_| Msg::OpenStacked)>
-                <MatButton label="Open stacked snackbar" raised=true  />
-             </span>
-            <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." snackbar_link=self.stacked_link.clone() stacked=true
-                onclosed=self.link.callback(Msg::StackedClosed)>
-                <span slot="action">
-                    <MatButton label="RETRY" />
-                </span>
+         <section style="margin: 1em 0;">
+             <span onclick={link.callback(|_| Msg::OpenStacked)}>
+                 <MatButton label="Open stacked snackbar" raised=true  />
+              </span>
+             <MatSnackbar label_text="Can't send photo. Retry in 5 seconds." snackbar_link={self.stacked_link.clone()} stacked=true
+                 onclosed={link.callback(Msg::StackedClosed)}>
+                 <span slot="action">
+                     <MatButton label="RETRY" />
+                 </span>
 
-                <span class="snackbar-dismiss-slot" slot="dismiss">
-                    <MatIconButton icon="close" />
-                </span>
-            </MatSnackbar>
-        </section>
+                 <span class="snackbar-dismiss-slot" slot="dismiss">
+                     <MatIconButton icon="close" />
+                 </span>
+             </MatSnackbar>
+         </section>
         }});
 
         html! {<>
-            <Codeblock title="Default" code_and_html=default />
+            <Codeblock title="Default" code_and_html={default} />
 
-            <Codeblock title="Leading" code_and_html=leading />
+            <Codeblock title="Leading" code_and_html={leading} />
 
-            <Codeblock title="Stacked" code_and_html=stacked />
+            <Codeblock title="Stacked" code_and_html={stacked} />
         </>}
     }
 }

--- a/website/src/components/switch.rs
+++ b/website/src/components/switch.rs
@@ -9,55 +9,47 @@ impl Component for Switch {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard = with_raw_code!(standard { html! {
-        <section class="demo">
-            <h3>{"Switch"}</h3>
-            <MatSwitch />
-        </section>
+         <section class="demo">
+             <h3>{"Switch"}</h3>
+             <MatSwitch />
+         </section>
         }});
 
         let checked = with_raw_code!(checked { html! {
-        <section class="demo">
-            <h3>{"Switch"}</h3>
-            <MatSwitch checked=true />
-        </section>
+         <section class="demo">
+             <h3>{"Switch"}</h3>
+             <MatSwitch checked=true />
+         </section>
         }});
 
         let disabled = with_raw_code!(disabled { html! {
-        <section class="demo">
-            <h3>{"Switch"}</h3>
-            <MatSwitch disabled=true />
-        </section>
+         <section class="demo">
+             <h3>{"Switch"}</h3>
+             <MatSwitch disabled=true />
+         </section>
         }});
 
         let disabled_checked = with_raw_code!(disabled_checked { html! {
-        <section class="demo">
-            <h3>{"Switch"}</h3>
-            <MatSwitch disabled=true checked=true />
-        </section>
+         <section class="demo">
+             <h3>{"Switch"}</h3>
+             <MatSwitch disabled=true checked=true />
+         </section>
         }});
 
         html! {<>
-            <Codeblock title="Standard" code_and_html=standard />
+            <Codeblock title="Standard" code_and_html={standard} />
 
-            <Codeblock title="Checked" code_and_html=checked />
+            <Codeblock title="Checked" code_and_html={checked} />
 
-            <Codeblock title="Disabled" code_and_html=disabled />
+            <Codeblock title="Disabled" code_and_html={disabled} />
 
-            <Codeblock title="Disabled checked" code_and_html=disabled_checked />
+            <Codeblock title="Disabled checked" code_and_html={disabled_checked} />
         </>}
     }
 }

--- a/website/src/components/tabs.rs
+++ b/website/src/components/tabs.rs
@@ -9,187 +9,179 @@ impl Component for Tabs {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let standard = with_raw_code!(standard { html! {
-        <MatTabBar>
-            <MatTab label="one" />
-            <MatTab label="two" />
-            <MatTab label="three" />
-        </MatTabBar>
+         <MatTabBar>
+             <MatTab label="one" />
+             <MatTab label="two" />
+             <MatTab label="three" />
+         </MatTabBar>
         }});
 
         let fading_indicator = with_raw_code!(fading_indicator { html! {
-        <section>
-            <MatTabBar>
-                <MatTab is_fading_indicator=true label="one" />
-                <MatTab is_fading_indicator=true label="two" />
-                <MatTab is_fading_indicator=true label="three" />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab is_fading_indicator=true label="one" />
+                 <MatTab is_fading_indicator=true label="two" />
+                 <MatTab is_fading_indicator=true label="three" />
+             </MatTabBar>
+         </section>
         }});
 
         let min_width_tab = with_raw_code!(min_width_tab { html! {
-        <section>
-            <MatTabBar>
-                <MatTab min_width=true label="one" />
-                <MatTab min_width=true label="two" />
-                <MatTab min_width=true label="three" />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab min_width=true label="one" />
+                 <MatTab min_width=true label="two" />
+                 <MatTab min_width=true label="three" />
+             </MatTabBar>
+         </section>
         }});
 
         let min_width_indicator = with_raw_code!(min_width_indicator { html! {
-        <section>
-            <MatTabBar>
-                <MatTab is_min_width_indicator=true label="one" />
-                <MatTab is_min_width_indicator=true label="two" />
-                <MatTab is_min_width_indicator=true label="three" />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab is_min_width_indicator=true label="one" />
+                 <MatTab is_min_width_indicator=true label="two" />
+                 <MatTab is_min_width_indicator=true label="three" />
+             </MatTabBar>
+         </section>
         }});
 
         let min_width_tab_indicator = with_raw_code!(min_width_tab_indicator { html! {
-        <section>
-            <MatTabBar>
-                <MatTab is_min_width_indicator=true min_width=true label="one" />
-                <MatTab is_min_width_indicator=true min_width=true label="two" />
-                <MatTab is_min_width_indicator=true min_width=true label="three" />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab is_min_width_indicator=true min_width=true label="one" />
+                 <MatTab is_min_width_indicator=true min_width=true label="two" />
+                 <MatTab is_min_width_indicator=true min_width=true label="three" />
+             </MatTabBar>
+         </section>
         }});
 
         let with_icons = with_raw_code!(with_icons { html! {
-        <section>
-            <MatTabBar>
-                <MatTab icon="accessibility" label="one" />
-                <MatTab icon="exit_to_app" label="two" />
-                <MatTab icon="camera" label="three" />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab icon="accessibility" label="one" />
+                 <MatTab icon="exit_to_app" label="two" />
+                 <MatTab icon="camera" label="three" />
+             </MatTabBar>
+         </section>
         }});
 
         let only_icons = with_raw_code!(only_icons { html! {
-        <section>
-            <MatTabBar>
-                <MatTab icon="accessibility" />
-                <MatTab icon="exit_to_app" />
-                <MatTab icon="camera" />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab icon="accessibility" />
+                 <MatTab icon="exit_to_app" />
+                 <MatTab icon="camera" />
+             </MatTabBar>
+         </section>
         }});
 
         let image_icons = with_raw_code!(image_icons { html! {
-        <section>
-            <MatTabBar>
-                <MatTab>
-                    <MatTabIcon>
-                        <svg width="10px" height="10px"><circle r="5px" cx="5px" cy="5px" color="red"></circle></svg>
-                    </MatTabIcon>
-                </MatTab>
-                <MatTab>
-                    <MatTabIcon>
-                        <svg width="10px" height="10px"><rect width="10px" height="10px" color="green"></rect></svg>
-                    </MatTabIcon>
-                </MatTab>
-                <MatTab>
-                    <MatTabIcon>
-                        <svg width="10px" height="10px"><rect width="10px" height="10px" color="green"></rect></svg>
-                    </MatTabIcon>
-                </MatTab>
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab>
+                     <MatTabIcon>
+                         <svg width="10px" height="10px"><circle r="5px" cx="5px" cy="5px" color="red"></circle></svg>
+                     </MatTabIcon>
+                 </MatTab>
+                 <MatTab>
+                     <MatTabIcon>
+                         <svg width="10px" height="10px"><rect width="10px" height="10px" color="green"></rect></svg>
+                     </MatTabIcon>
+                 </MatTab>
+                 <MatTab>
+                     <MatTabIcon>
+                         <svg width="10px" height="10px"><rect width="10px" height="10px" color="green"></rect></svg>
+                     </MatTabIcon>
+                 </MatTab>
+             </MatTabBar>
+         </section>
         }});
 
         let with_icons_stacked = with_raw_code!(with_icons_stacked { html! {
-        <section>
-            <MatTabBar>
-                <MatTab icon="accessibility" label="one" stacked=true />
-                <MatTab icon="exit_to_app" label="two" stacked=true />
-                <MatTab icon="camera" label="three" stacked=true />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab icon="accessibility" label="one" stacked=true />
+                 <MatTab icon="exit_to_app" label="two" stacked=true />
+                 <MatTab icon="camera" label="three" stacked=true />
+             </MatTabBar>
+         </section>
         }});
 
         let with_icons_stacked_min_width = with_raw_code!(with_icons_stacked_min_width { html! {
-        <section>
-            <MatTabBar>
-                <MatTab icon="accessibility" label="one" stacked=true is_min_width_indicator=true />
-                <MatTab icon="exit_to_app" label="two" stacked=true is_min_width_indicator=true />
-                <MatTab icon="camera" label="three" stacked=true is_min_width_indicator=true />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab icon="accessibility" label="one" stacked=true is_min_width_indicator=true />
+                 <MatTab icon="exit_to_app" label="two" stacked=true is_min_width_indicator=true />
+                 <MatTab icon="camera" label="three" stacked=true is_min_width_indicator=true />
+             </MatTabBar>
+         </section>
         }});
 
         let scrolling = with_raw_code!(scrolling { html! {
-        <section style="width: 390px">
-            <MatTabBar>
-                <MatTab label="one" />
-                <MatTab label="two" />
-                <MatTab label="three" />
-                <MatTab label="four" />
-                <MatTab label="five" />
-                <MatTab label="six" />
-                <MatTab label="seven" />
-                <MatTab label="eight" />
-                <MatTab label="nine" />
-                <MatTab label="ten" />
-            </MatTabBar>
-        </section>
+         <section style="width: 390px">
+             <MatTabBar>
+                 <MatTab label="one" />
+                 <MatTab label="two" />
+                 <MatTab label="three" />
+                 <MatTab label="four" />
+                 <MatTab label="five" />
+                 <MatTab label="six" />
+                 <MatTab label="seven" />
+                 <MatTab label="eight" />
+                 <MatTab label="nine" />
+                 <MatTab label="ten" />
+             </MatTabBar>
+         </section>
         }});
 
         let scrolling_with_icons_stacked_min_width = with_raw_code!(scrolling_with_icons_stacked_min_width { html! {
-        <section style="width: 460px">
-            <MatTabBar>
-                <MatTab label="one" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="two" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="three" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="four" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="five" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="six" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="seven" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="eight" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="nine" stacked=true is_min_width_indicator=true icon="camera" />
-                <MatTab label="ten" stacked=true is_min_width_indicator=true icon="camera" />
-            </MatTabBar>
-        </section>
+         <section style="width: 460px">
+             <MatTabBar>
+                 <MatTab label="one" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="two" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="three" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="four" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="five" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="six" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="seven" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="eight" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="nine" stacked=true is_min_width_indicator=true icon="camera" />
+                 <MatTab label="ten" stacked=true is_min_width_indicator=true icon="camera" />
+             </MatTabBar>
+         </section>
         }});
 
         let with_icons_no_label = with_raw_code!(with_icons_no_label { html! {
-        <section>
-            <MatTabBar>
-                <MatTab icon="accessibility" indicator_icon="donut_large" is_fading_indicator=true />
-                <MatTab icon="exit_to_app" indicator_icon="donut_large" is_fading_indicator=true />
-                <MatTab icon="camera" indicator_icon="donut_large" is_fading_indicator=true />
-            </MatTabBar>
-        </section>
+         <section>
+             <MatTabBar>
+                 <MatTab icon="accessibility" indicator_icon="donut_large" is_fading_indicator=true />
+                 <MatTab icon="exit_to_app" indicator_icon="donut_large" is_fading_indicator=true />
+                 <MatTab icon="camera" indicator_icon="donut_large" is_fading_indicator=true />
+             </MatTabBar>
+         </section>
         }});
 
         html! {<main class="tab-component">
-            <Codeblock title="Standard" code_and_html=standard max_width=100 />
-            <Codeblock title="Fading indicator" code_and_html=fading_indicator max_width=100 />
-            <Codeblock title="Min Width Tab" code_and_html=min_width_tab max_width=100 />
-            <Codeblock title="Min Width Indicator" code_and_html=min_width_indicator max_width=100 />
-            <Codeblock title="Min Width Tab - Min Width Indicator" code_and_html=min_width_tab_indicator max_width=100 />
-            <Codeblock title="With Icons" code_and_html=with_icons max_width=100 />
-            <Codeblock title="Only Icons" code_and_html=only_icons max_width=100 />
-            <Codeblock title="Image Icons" code_and_html=image_icons max_width=100 />
-            <Codeblock title="With Icons - Stacked" code_and_html=with_icons_stacked max_width=100 />
-            <Codeblock title="With Icons - Stacked - Min Width Indicator" code_and_html=with_icons_stacked_min_width max_width=100 />
-            <Codeblock title="Scrolling" code_and_html=scrolling max_width=100 />
-            <Codeblock title="Scrolling - Width Icons - Stacked - Min Width Indicator" code_and_html=scrolling_with_icons_stacked_min_width max_width=100 />
-            <Codeblock title="With Icons" code_and_html=with_icons_no_label max_width=100 />
+            <Codeblock title="Standard" code_and_html={standard} max_width=100 />
+            <Codeblock title="Fading indicator" code_and_html={fading_indicator}  max_width=100 />
+            <Codeblock title="Min Width Tab" code_and_html={min_width_tab} max_width=100 />
+            <Codeblock title="Min Width Indicator" code_and_html={min_width_indicator} max_width=100 />
+            <Codeblock title="Min Width Tab - Min Width Indicator" code_and_html={min_width_tab_indicator} max_width=100 />
+            <Codeblock title="With Icons" code_and_html={with_icons} max_width=100 />
+            <Codeblock title="Only Icons" code_and_html={only_icons} max_width=100 />
+            <Codeblock title="Image Icons" code_and_html={image_icons} max_width=100 />
+            <Codeblock title="With Icons - Stacked" code_and_html={with_icons_stacked} max_width=100 />
+            <Codeblock title="With Icons - Stacked - Min Width Indicator" code_and_html={with_icons_stacked_min_width} max_width=100 />
+            <Codeblock title="Scrolling" code_and_html={scrolling} max_width=100 />
+            <Codeblock title="Scrolling - Width Icons - Stacked - Min Width Indicator" code_and_html={scrolling_with_icons_stacked_min_width} max_width=100 />
+            <Codeblock title="With Icons" code_and_html={with_icons_no_label} max_width=100 />
         </main>}
     }
 }

--- a/website/src/components/textarea.rs
+++ b/website/src/components/textarea.rs
@@ -10,19 +10,11 @@ impl Component for TextArea {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let validity_transform = MatTextArea::validity_transform(move |_, _| {
             let mut state = ValidityState::new();
             state.set_valid(false).set_bad_input(true);
@@ -30,36 +22,36 @@ impl Component for TextArea {
         });
 
         let standard = with_raw_code!(standard { html! {
-        <section class="demo-group-spaced">
-            <MatTextArea label="Standard" validity_transform=validity_transform.clone() />
-            <MatTextArea outlined=true label="Standard" validity_transform=validity_transform />
-            <br />
-            <p>{"Note: validation for both of these text areas always fail"}</p>
-        </section>
+         <section class="demo-group-spaced">
+             <MatTextArea label="Standard" validity_transform={validity_transform.clone()} />
+             <MatTextArea outlined=true label="Standard" validity_transform={validity_transform} />
+             <br />
+             <p>{"Note: validation for both of these text areas always fail"}</p>
+         </section>
         }});
 
         let with_char_counter = with_raw_code!(with_char_counter { html! {
-        <section class="demo-group-spaced">
-            <MatTextArea label="Standard" max_length=18 char_counter=TextAreaCharCounter::External />
-            <MatTextArea outlined=true label="Standard" max_length=18 char_counter=TextAreaCharCounter::Internal />
-        </section>
+         <section class="demo-group-spaced">
+             <MatTextArea label="Standard" max_length=18 char_counter={TextAreaCharCounter::External} />
+             <MatTextArea outlined=true label="Standard" max_length=18 char_counter={TextAreaCharCounter::Internal} />
+         </section>
         }});
 
         let with_helper_text = with_raw_code!(with_helper_text { html! {
-        <section class="demo-group-spaced shaped-outlined">
-            <MatTextArea label="Standard" helper="Helper Text" helper_persistent=true />
-            <MatTextArea outlined=true label="Standard" helper="Helper Text" helper_persistent=true />
-        </section>
+         <section class="demo-group-spaced shaped-outlined">
+             <MatTextArea label="Standard" helper="Helper Text" helper_persistent=true />
+             <MatTextArea outlined=true label="Standard" helper="Helper Text" helper_persistent=true />
+         </section>
         }});
 
         html! { <main class="textfield-demo">
 
-            <Codeblock title="Standard Textarea" code_and_html=standard />
+            <Codeblock title="Standard Textarea" code_and_html={standard} />
 
-            <Codeblock title="Textarea with Character Counter" code_and_html=with_char_counter />
+            <Codeblock title="Textarea with Character Counter" code_and_html={with_char_counter} />
 
-            <Codeblock title="Textarea with Helper Text" code_and_html=with_helper_text />
+            <Codeblock title="Textarea with Helper Text" code_and_html={with_helper_text} />
 
-        </main> }
+        </main>}
     }
 }

--- a/website/src/components/textfield.rs
+++ b/website/src/components/textfield.rs
@@ -12,19 +12,11 @@ impl Component for Textfield {
     type Message = ();
     type Properties = ();
 
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {}
     }
 
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         let validity_transform = MatTextField::validity_transform(move |_, _| {
             let mut state = ValidityState::new();
             state.set_valid(false).set_bad_input(true);
@@ -32,51 +24,51 @@ impl Component for Textfield {
         });
 
         let filled = with_raw_code!(filled { html! {
-        <div class="demo-group-spaced">
-            <MatTextField label="Standard (always fails validity check)" validity_transform=validity_transform.clone() />
-            <MatTextField label="Standard" icon="event" field_type=TextFieldType::Date />
-            <MatTextField label="Standard" icon_trailing="delete" />
-        </div>
+         <div class="demo-group-spaced">
+             <MatTextField label="Standard (always fails validity check)" validity_transform={validity_transform.clone()} />
+             <MatTextField label="Standard" icon="event" field_type={TextFieldType::Date} />
+             <MatTextField label="Standard" icon_trailing="delete" />
+         </div>
         }});
 
         let outlined = with_raw_code!(outlined { html! {
-        <div class="demo-group-spaced">
-            <MatTextField outlined=true label="Outlined (always fails validity check) " validity_transform=validity_transform />
-            <MatTextField outlined=true label="Outlined" icon="event" field_type=TextFieldType::Time />
-            <MatTextField outlined=true label="Outlined" icon_trailing="delete" />
-        </div>
+         <div class="demo-group-spaced">
+             <MatTextField outlined=true label="Outlined (always fails validity check) " validity_transform={validity_transform} />
+             <MatTextField outlined=true label="Outlined" icon="event" field_type={TextFieldType::Time} />
+             <MatTextField outlined=true label="Outlined" icon_trailing="delete" />
+         </div>
         }});
 
         let without_label = with_raw_code!(without_label { html! {
-        <div class="demo-group-spaced">
-            <MatTextField helper="Helper Text" />
-            <MatTextField outlined=true helper="Helper Text" />
-            <span class="shaped-outlined">
-                <MatTextField outlined=true helper="Helper Text" />
-            </span>
-        </div>
+         <div class="demo-group-spaced">
+             <MatTextField helper="Helper Text" />
+             <MatTextField outlined=true helper="Helper Text" />
+             <span class="shaped-outlined">
+                 <MatTextField outlined=true helper="Helper Text" />
+             </span>
+         </div>
         }});
 
         let with_char_counter = with_raw_code!(with_char_counter { html! {
-        <div class="demo-group-spaced">
-            <MatTextField label="Standard" helper="Helper Text" helper_persistent=true max_length=18 char_counter=true />
-            <MatTextField outlined=true label="Standard" helper="Helper Text" helper_persistent=true max_length=18 char_counter=true />
-            <span class="shaped-outlined">
-                <MatTextField outlined=true label="Standard" helper="Helper Text" helper_persistent=true max_length=18 char_counter=true />
-            </span>
-        </div>
+         <div class="demo-group-spaced">
+             <MatTextField label="Standard" helper="Helper Text" helper_persistent=true max_length=18 char_counter=true />
+             <MatTextField outlined=true label="Standard" helper="Helper Text" helper_persistent=true max_length=18 char_counter=true />
+             <span class="shaped-outlined">
+                 <MatTextField outlined=true label="Standard" helper="Helper Text" helper_persistent=true max_length=18 char_counter=true />
+             </span>
+         </div>
         }});
 
         html! {
-            <main class="textfield-demo">
-                <Codeblock title="Filled" code_and_html=filled max_width=100 />
+             <main class="textfield-demo">
+                 <Codeblock title="Filled" code_and_html={filled} max_width=100 />
 
-                <Codeblock title="Outlined" code_and_html=outlined max_width=100 />
+                 <Codeblock title="Outlined" code_and_html={outlined} max_width=100 />
 
-                <Codeblock title="Text Field without label" code_and_html=without_label max_width=100 />
+                 <Codeblock title="Text Field without label" code_and_html={without_label} max_width=100 />
 
-                <Codeblock title="Text Field with Character Counter" code_and_html=with_char_counter max_width=100 />
-            </main>
+                 <Codeblock title="Text Field with Character Counter" code_and_html={with_char_counter} max_width=100 />
+             </main>
         }
     }
 }

--- a/website/src/lib.rs
+++ b/website/src/lib.rs
@@ -150,79 +150,79 @@ impl Component for App {
         };
 
         html! { <>
-        <MatDrawer open={self.drawer_state} drawer_type="dismissible"
-            onopened={link.callback(|_| Msg::Opened)}
-            onclosed={link.callback(|_| Msg::Closed)}>
+        <BrowserRouter>
+            <MatDrawer open={self.drawer_state} drawer_type="dismissible"
+                onopened={link.callback(|_| Msg::Opened)}
+                onclosed={link.callback(|_| Msg::Closed)}>
 
-                <MatDrawerTitle>
-                    <span class="drawer-title">{"Components"}</span>
-                </MatDrawerTitle>
+                    <MatDrawerTitle>
+                        <span class="drawer-title">{"Components"}</span>
+                    </MatDrawerTitle>
 
-                <div class="drawer-content">
-                    <MatList>
-                        <AppLink to={AppRoute::Button}><MatListItem>{"Button"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Checkbox}><MatListItem>{"Checkbox"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Radio}><MatListItem>{"Radio"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Switch}><MatListItem>{"Switch"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Fab}><MatListItem>{"Floating Action Button"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::IconButton}><MatListItem>{"Icon Button"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Icon}><MatListItem>{"Icon"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::CircularProgress}><MatListItem>{"Circular Progress"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::FormField}><MatListItem>{"Form Field"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::LinearProgress}><MatListItem>{"Linear Progress"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::List}><MatListItem>{"List"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::IconButtonToggle}><MatListItem>{"Icon Button Toggle"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Slider}><MatListItem>{"Slider"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Tabs}><MatListItem>{"Tabs"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Snackbar}><MatListItem>{"Snackbar"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Textfield}><MatListItem>{"Textfield"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::TextArea}><MatListItem>{"TextArea"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Select}><MatListItem>{"Select"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Menu}><MatListItem>{"Menu"}</MatListItem></AppLink>
-                        <AppLink to={AppRoute::Dialog}><MatListItem>{"Dialog"}</MatListItem></AppLink>
-                    </MatList>
-                </div>
-                <MatDrawerAppContent>
-                    <div class="app-content">
-                        <MatTopAppBarFixed onnavigationiconclick={link.callback(|_| Msg::NavIconClick)}>
-                            <MatTopAppBarNavigationIcon>
-                                <MatIconButton icon="menu"></MatIconButton>
-                            </MatTopAppBarNavigationIcon>
-
-                            <MatTopAppBarTitle>
-                                <div class="app-title">
-                                    <AppLink to={AppRoute::Home}>
-                                        <h1>{"Material Yew"}</h1>
-                                    </AppLink>
-                                    <span class="action-item">
-                                        <AppLink to={AppRoute::Components}>
-                                            {components}
-                                        </AppLink>
-                                    </span>
-                                </div>
-                            </MatTopAppBarTitle>
-
-                            <MatTopAppBarActionItems>
-                                <a class="action-item" href="https://github.com/hamza1311/yew-material">
-                                    {github}
-                                </a>
-                            </MatTopAppBarActionItems>
-
-                            <MatTopAppBarActionItems>
-                                <a class="action-item" href="/docs/material_yew">
-                                    {docs}
-                                </a>
-                            </MatTopAppBarActionItems>
-
-                        </MatTopAppBarFixed>
-                        <main id="router-outlet">
-                        <BrowserRouter>
-                            <yew_router::Switch<AppRoute> render={yew_router::Switch::render(Self::switch)} />
-                        </BrowserRouter>
-                        </main>
+                    <div class="drawer-content">
+                        <MatList>
+                            <AppLink to={AppRoute::Button}><MatListItem>{"Button"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Checkbox}><MatListItem>{"Checkbox"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Radio}><MatListItem>{"Radio"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Switch}><MatListItem>{"Switch"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Fab}><MatListItem>{"Floating Action Button"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::IconButton}><MatListItem>{"Icon Button"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Icon}><MatListItem>{"Icon"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::CircularProgress}><MatListItem>{"Circular Progress"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::FormField}><MatListItem>{"Form Field"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::LinearProgress}><MatListItem>{"Linear Progress"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::List}><MatListItem>{"List"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::IconButtonToggle}><MatListItem>{"Icon Button Toggle"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Slider}><MatListItem>{"Slider"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Tabs}><MatListItem>{"Tabs"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Snackbar}><MatListItem>{"Snackbar"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Textfield}><MatListItem>{"Textfield"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::TextArea}><MatListItem>{"TextArea"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Select}><MatListItem>{"Select"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Menu}><MatListItem>{"Menu"}</MatListItem></AppLink>
+                            <AppLink to={AppRoute::Dialog}><MatListItem>{"Dialog"}</MatListItem></AppLink>
+                        </MatList>
                     </div>
-                </MatDrawerAppContent>
-            </MatDrawer>
+                    <MatDrawerAppContent>
+                        <div class="app-content">
+                            <MatTopAppBarFixed onnavigationiconclick={link.callback(|_| Msg::NavIconClick)}>
+                                <MatTopAppBarNavigationIcon>
+                                    <MatIconButton icon="menu"></MatIconButton>
+                                </MatTopAppBarNavigationIcon>
+
+                                <MatTopAppBarTitle>
+                                    <div class="app-title">
+                                        <AppLink to={AppRoute::Home}>
+                                            <h1>{"Material Yew"}</h1>
+                                        </AppLink>
+                                        <span class="action-item">
+                                            <AppLink to={AppRoute::Components}>
+                                                {components}
+                                            </AppLink>
+                                        </span>
+                                    </div>
+                                </MatTopAppBarTitle>
+
+                                <MatTopAppBarActionItems>
+                                    <a class="action-item" href="https://github.com/hamza1311/yew-material">
+                                        {github}
+                                    </a>
+                                </MatTopAppBarActionItems>
+
+                                <MatTopAppBarActionItems>
+                                    <a class="action-item" href="/docs/material_yew">
+                                        {docs}
+                                    </a>
+                                </MatTopAppBarActionItems>
+
+                            </MatTopAppBarFixed>
+                            <main id="router-outlet">
+                                <yew_router::Switch<AppRoute> render={yew_router::Switch::render(Self::switch)} />
+                            </main>
+                        </div>
+                    </MatDrawerAppContent>
+                </MatDrawer>
+            </BrowserRouter>
         </>}
     }
 }

--- a/website/src/lib.rs
+++ b/website/src/lib.rs
@@ -19,61 +19,59 @@ use syntect::highlighting::Theme;
 use syntect::parsing::SyntaxSet;
 use wasm_bindgen::prelude::*;
 
-#[derive(Switch, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Routable)]
 pub enum AppRoute {
-    #[to = "/components/button"]
+    #[at("/components/button")]
     Button,
-    #[to = "/components/checkbox"]
+    #[at("/components/checkbox")]
     Checkbox,
-    #[to = "/components/radio"]
+    #[at("/components/radio")]
     Radio,
-    #[to = "/components/switch"]
+    #[at("/components/switch")]
     Switch,
-    #[to = "/components/fab"]
+    #[at("/components/fab")]
     Fab,
-    #[to = "/components/icon-button-toggle"]
+    #[at("/components/icon-button-toggle")]
     IconButtonToggle,
-    #[to = "/components/icon-button"]
+    #[at("/components/icon-button")]
     IconButton,
-    #[to = "/components/icon"]
+    #[at("/components/icon")]
     Icon,
-    #[to = "/components/circular-progress"]
+    #[at("/components/circular-progress")]
     CircularProgress,
-    #[to = "/components/drawer"]
+    #[at("/components/drawer")]
     Drawer,
-    #[to = "/components/form-field"]
+    #[at("/components/form-field")]
     FormField,
-    #[to = "/components/linear-progress"]
+    #[at("/components/linear-progress")]
     LinearProgress,
-    #[to = "/components/list"]
+    #[at("/components/list")]
     List,
-    #[to = "/components/slider"]
+    #[at("/components/slider")]
     Slider,
-    #[to = "/components/tabs"]
+    #[at("/components/tabs")]
     Tabs,
-    #[to = "/components/snackbar"]
+    #[at("/components/snackbar")]
     Snackbar,
-    #[to = "/components/textfield"]
+    #[at("/components/textfield")]
     Textfield,
-    #[to = "/components/textarea"]
+    #[at("/components/textarea")]
     TextArea,
-    #[to = "/components/select"]
+    #[at("/components/select")]
     Select,
-    #[to = "/components/menu"]
+    #[at("/components/menu")]
     Menu,
-    #[to = "/components/dialog"]
+    #[at("/components/dialog")]
     Dialog,
-    #[to = "/components"]
+    #[at("/components")]
     Components,
-    #[to = "/"]
+    #[at("/")]
     Home,
 }
 
-type AppRouter = Router<AppRoute>;
-type AppRouterAnchor = RouterAnchor<AppRoute>;
+type AppLink = Link<AppRoute>;
 
 pub struct App {
-    link: ComponentLink<Self>,
     /// `true` represents open; `false` represents close
     drawer_state: bool,
 }
@@ -98,14 +96,13 @@ impl Component for App {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             drawer_state: false,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::NavIconClick => {
                 self.drawer_state = !self.drawer_state;
@@ -121,43 +118,41 @@ impl Component for App {
             }
         }
     }
-    fn change(&mut self, _props: Self::Properties) -> bool {
-        false
-    }
 
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
         let is_on_mobile = is_on_mobile();
 
         let components = if !is_on_mobile {
-            html! { <MatButton label="Components"/> }
+            html! { <MatButton label="Components"/>}
         } else {
             html! {
-                <MatIconButton label="Components">
-                    <img src="/assets/components.png" alt="Components" />
-                </MatIconButton>
+                 <MatIconButton label="Components">
+                     <img src="/assets/components.png" alt="Components" />
+                 </MatIconButton>
             }
         };
 
         let docs = if !is_on_mobile {
-            html! { <MatButton label="API Docs"/> }
+            html! { <MatButton label="API Docs"/>}
         } else {
-            html! { <MatIconButton icon="description" label="API Docs" /> }
+            html! { <MatIconButton icon="description" label="API Docs" />}
         };
 
         let github = if !is_on_mobile {
-            html! { <MatButton label="GitHub" /> }
+            html! { <MatButton label="GitHub" />}
         } else {
             html! {
-                <MatIconButton label="GitHub">
-                    <img src="/assets/github.png" alt="GitHub logo" />
-                </MatIconButton>
+                 <MatIconButton label="GitHub">
+                     <img src="/assets/github.png" alt="GitHub logo" />
+                 </MatIconButton>
             }
         };
 
         html! { <>
-        <MatDrawer open=self.drawer_state drawer_type="dismissible"
-            onopened=self.link.callback(|_| Msg::Opened)
-            onclosed=self.link.callback(|_| Msg::Closed)>
+        <MatDrawer open={self.drawer_state} drawer_type="dismissible"
+            onopened={link.callback(|_| Msg::Opened)}
+            onclosed={link.callback(|_| Msg::Closed)}>
 
                 <MatDrawerTitle>
                     <span class="drawer-title">{"Components"}</span>
@@ -165,102 +160,99 @@ impl Component for App {
 
                 <div class="drawer-content">
                     <MatList>
-                        <AppRouterAnchor route=AppRoute::Button><MatListItem>{"Button"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Checkbox><MatListItem>{"Checkbox"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Radio><MatListItem>{"Radio"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Switch><MatListItem>{"Switch"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Fab><MatListItem>{"Floating Action Button"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::IconButton><MatListItem>{"Icon Button"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Icon><MatListItem>{"Icon"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::CircularProgress><MatListItem>{"Circular Progress"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::FormField><MatListItem>{"Form Field"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::LinearProgress><MatListItem>{"Linear Progress"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::List><MatListItem>{"List"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::IconButtonToggle><MatListItem>{"Icon Button Toggle"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Slider><MatListItem>{"Slider"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Tabs><MatListItem>{"Tabs"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Snackbar><MatListItem>{"Snackbar"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Textfield><MatListItem>{"Textfield"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::TextArea><MatListItem>{"TextArea"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Select><MatListItem>{"Select"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Menu><MatListItem>{"Menu"}</MatListItem></AppRouterAnchor>
-                        <AppRouterAnchor route=AppRoute::Dialog><MatListItem>{"Dialog"}</MatListItem></AppRouterAnchor>
+                        <AppLink to={AppRoute::Button}><MatListItem>{"Button"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Checkbox}><MatListItem>{"Checkbox"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Radio}><MatListItem>{"Radio"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Switch}><MatListItem>{"Switch"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Fab}><MatListItem>{"Floating Action Button"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::IconButton}><MatListItem>{"Icon Button"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Icon}><MatListItem>{"Icon"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::CircularProgress}><MatListItem>{"Circular Progress"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::FormField}><MatListItem>{"Form Field"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::LinearProgress}><MatListItem>{"Linear Progress"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::List}><MatListItem>{"List"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::IconButtonToggle}><MatListItem>{"Icon Button Toggle"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Slider}><MatListItem>{"Slider"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Tabs}><MatListItem>{"Tabs"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Snackbar}><MatListItem>{"Snackbar"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Textfield}><MatListItem>{"Textfield"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::TextArea}><MatListItem>{"TextArea"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Select}><MatListItem>{"Select"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Menu}><MatListItem>{"Menu"}</MatListItem></AppLink>
+                        <AppLink to={AppRoute::Dialog}><MatListItem>{"Dialog"}</MatListItem></AppLink>
                     </MatList>
                 </div>
                 <MatDrawerAppContent>
                     <div class="app-content">
-                        <MatTopAppBarFixed onnavigationiconclick=self.link.callback(|_| Msg::NavIconClick)>
+                        <MatTopAppBarFixed onnavigationiconclick={link.callback(|_| Msg::NavIconClick)}>
                             <MatTopAppBarNavigationIcon>
                                 <MatIconButton icon="menu"></MatIconButton>
                             </MatTopAppBarNavigationIcon>
 
                             <MatTopAppBarTitle>
                                 <div class="app-title">
-                                    <AppRouterAnchor route=AppRoute::Home>
+                                    <AppLink to={AppRoute::Home}>
                                         <h1>{"Material Yew"}</h1>
-                                    </AppRouterAnchor>
+                                    </AppLink>
                                     <span class="action-item">
-                                        <AppRouterAnchor route=AppRoute::Components>
-                                            { components }
-                                        </AppRouterAnchor>
+                                        <AppLink to={AppRoute::Components}>
+                                            {components}
+                                        </AppLink>
                                     </span>
                                 </div>
                             </MatTopAppBarTitle>
 
                             <MatTopAppBarActionItems>
                                 <a class="action-item" href="https://github.com/hamza1311/yew-material">
-                                    { github }
+                                    {github}
                                 </a>
                             </MatTopAppBarActionItems>
 
                             <MatTopAppBarActionItems>
                                 <a class="action-item" href="/docs/material_yew">
-                                    { docs }
+                                    {docs}
                                 </a>
                             </MatTopAppBarActionItems>
 
                         </MatTopAppBarFixed>
                         <main id="router-outlet">
-                        <AppRouter
-                            render=AppRouter::render(Self::switch)
-                            // redirect=AppRouter::redirect(|route: Route| {
-                            //     AppRoute::PageNotFound(Permissive(Some(route.route))).into_public()
-                            // })
-                        />
+                        <BrowserRouter>
+                            <yew_router::Switch<AppRoute> render={yew_router::Switch::render(Self::switch)} />
+                        </BrowserRouter>
                         </main>
                     </div>
                 </MatDrawerAppContent>
             </MatDrawer>
-        </> }
+        </>}
     }
 }
 
 impl App {
-    fn switch(switch: AppRoute) -> Html {
+    fn switch(switch: &AppRoute) -> Html {
         match switch {
-            AppRoute::Home => html! { <Home /> },
-            AppRoute::Components => html! { <Components /> },
-            AppRoute::Button => html! { <Button /> },
-            AppRoute::Checkbox => html! { <Checkbox /> },
-            AppRoute::Radio => html! { <Radio /> },
-            AppRoute::Switch => html! { <Switch /> },
-            AppRoute::Fab => html! { <Fab /> },
-            AppRoute::IconButton => html! { <IconButton /> },
-            AppRoute::Icon => html! { <Icon /> },
-            AppRoute::CircularProgress => html! { <CircularProgress /> },
-            AppRoute::Drawer => html! { <Drawer /> },
-            AppRoute::FormField => html! { <FormField /> },
-            AppRoute::LinearProgress => html! { <LinearProgress /> },
-            AppRoute::List => html! { <List /> },
-            AppRoute::IconButtonToggle => html! { <IconButtonToggle /> },
-            AppRoute::Slider => html! { <Slider /> },
-            AppRoute::Tabs => html! { <Tabs /> },
-            AppRoute::Snackbar => html! { <Snackbar /> },
-            AppRoute::Textfield => html! { <Textfield /> },
-            AppRoute::TextArea => html! { <TextArea /> },
-            AppRoute::Select => html! { <Select /> },
-            AppRoute::Menu => html! { <Menu /> },
-            AppRoute::Dialog => html! { <Dialog /> },
+            AppRoute::Home => html! { <Home />},
+            AppRoute::Components => html! { <Components />},
+            AppRoute::Button => html! { <Button />},
+            AppRoute::Checkbox => html! { <Checkbox />},
+            AppRoute::Radio => html! { <Radio />},
+            AppRoute::Switch => html! { <Switch />},
+            AppRoute::Fab => html! { <Fab />},
+            AppRoute::IconButton => html! { <IconButton />},
+            AppRoute::Icon => html! { <Icon />},
+            AppRoute::CircularProgress => html! { <CircularProgress />},
+            AppRoute::Drawer => html! { <Drawer />},
+            AppRoute::FormField => html! { <FormField />},
+            AppRoute::LinearProgress => html! { <LinearProgress />},
+            AppRoute::List => html! { <List />},
+            AppRoute::IconButtonToggle => html! { <IconButtonToggle />},
+            AppRoute::Slider => html! { <Slider />},
+            AppRoute::Tabs => html! { <Tabs />},
+            AppRoute::Snackbar => html! { <Snackbar />},
+            AppRoute::Textfield => html! { <Textfield />},
+            AppRoute::TextArea => html! { <TextArea />},
+            AppRoute::Select => html! { <Select />},
+            AppRoute::Menu => html! { <Menu />},
+            AppRoute::Dialog => html! { <Dialog />},
         }
     }
 }
@@ -280,7 +272,7 @@ fn html_to_element(html: &str) -> Html {
 }
 
 pub fn is_on_mobile() -> bool {
-    yew::utils::window()
+    gloo_utils::window()
         .match_media("(max-width: 600px)")
         .unwrap()
         .unwrap()

--- a/website/src/macros.rs
+++ b/website/src/macros.rs
@@ -26,9 +26,9 @@ pub fn highlight(code: &str, extension: &str) -> String {
             .unwrap();
         syntect::html::highlighted_html_for_string(
             code,
-            &data.syntax_set.as_ref().unwrap(),
+            data.syntax_set.as_ref().unwrap(),
             syntax,
-            &data.theme.as_ref().unwrap(),
+            data.theme.as_ref().unwrap(),
         )
     })
 }

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -10,5 +10,5 @@ fn main() {
             "../syntect-dumps/syntax-set.syntax"
         )));
     });
-    yew::start_app::<App>()
+    yew::start_app::<App>();
 }


### PR DESCRIPTION
Notes:

- Running `cargo +nightly fmt` generated a lot of whitespace changes in `html!()` calls, which is unfortunate.
- `Cow<'static, str>` replaced with `Option<AttrValue>` since `IntoPropValue` is not implemented on `Cow` anymore.
- `InputData` was removed from yew. I've made some (presumably quite dodgy) changes to handle this - this is probably worth having a closer look at. 


Resolves #15 

