### PR TITLE
text-inputs::event

### DIFF
--- a/material-yew/src/text_inputs/mod.rs
+++ b/material-yew/src/text_inputs/mod.rs
@@ -24,8 +24,8 @@ pub use web_sys::ValidityState as NativeValidityState;
 use std::rc::Rc;
 
 use gloo::events::EventListener;
-use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{Element, Event, InputEvent};
+use wasm_bindgen::JsValue;
+use web_sys::{Element, Event};
 use yew::{Callback, NodeRef};
 
 #[cfg(any(feature = "textfield", feature = "textarea"))]
@@ -55,16 +55,12 @@ impl PartialEq for ValidityTransform {
 fn set_on_input_handler(
     node_ref: &NodeRef,
     callback: Callback<String>,
-    convert: impl Fn((InputEvent, JsValue)) -> String + 'static,
+    convert: impl Fn((Event, JsValue)) -> String + 'static,
 ) -> EventListener {
     let element = node_ref.cast::<Element>().unwrap();
     EventListener::new(&element, "input", move |event: &Event| {
         let js_value = JsValue::from(event);
 
-        if let Some(input_event) = JsCast::dyn_ref::<web_sys::InputEvent>(&js_value) {
-            callback.emit(convert((input_event.clone(), js_value)))
-        } else {
-            panic!("could not convert to `InputEvent`");
-        }
+        callback.emit(convert((event.clone(), js_value)))
     })
 }


### PR DESCRIPTION
For text field types like Date, the event is not of type InputEvent (just Event), so the component panics. This removes the (unused) conversion to InputEvent.

Happy to talk more about this change, just let me know!