### PR TITLE
Enable stateful callbacks

### DIFF
--- a/material-yew/src/utils/listener.rs
+++ b/material-yew/src/utils/listener.rs
@@ -1,0 +1,41 @@
+use gloo::events::EventListener;
+use std::borrow::Cow;
+use web_sys::{Event, EventTarget};
+use yew::Callback;
+
+pub struct Listener<IN> {
+    el: Option<EventListener>,
+    cb: Option<Callback<IN>>,
+}
+
+impl<IN> Listener<IN> {
+    pub fn set<S, F, N>(
+        &mut self,
+        target: &EventTarget,
+        event_type: S,
+        cb: &yew::Callback<IN>,
+        new_cb: N,
+    ) where
+        S: Into<Cow<'static, str>>,
+        F: FnMut(&Event) + 'static,
+        N: FnOnce(Callback<IN>) -> F,
+    {
+        if match self.cb.as_ref() {
+            None => true,
+            Some(old_cb) => old_cb != cb,
+        } {
+            self.el = Some(EventListener::new(
+                target,
+                event_type,
+                (new_cb)(cb.to_owned()),
+            ));
+            self.cb = Some(cb.to_owned());
+        }
+    }
+}
+
+impl<IN> Default for Listener<IN> {
+    fn default() -> Self {
+        Self { el: None, cb: None }
+    }
+}

--- a/material-yew/src/utils/mod.rs
+++ b/material-yew/src/utils/mod.rs
@@ -1,2 +1,5 @@
 mod weak_component_link;
 pub use weak_component_link::*;
+
+mod listener;
+pub(crate) use listener::*;


### PR DESCRIPTION
It's possible that a callback is rendered with captured information from the time of the render (so it changes over time). For example, if the menu list changes, and the callback needs to resolve an integer index into a value from the list. 

In the current approach, after the callback is set the first time, it's never updated. 

This is a proposal to update the listeners as the callbacks are changed. There are a number of different ways to handle this (for example, moving the action/attribute name to bind to into a `new` function, rather than specifying it in the `render` function), and I'm happy to talk more and iterate on this (names, structure, etc). Please let me know what you think of this approach!

If this (or a variation of this works), I could probably tackle updating a number of the elements to follow this approach.